### PR TITLE
use shared classloader in graylog-server

### DIFF
--- a/src/main/resources/org.graylog.plugins.graylog-plugin-threatintel/graylog-plugin.properties
+++ b/src/main/resources/org.graylog.plugins.graylog-plugin-threatintel/graylog-plugin.properties
@@ -9,4 +9,4 @@ graylog.version=${graylog.version}
 # with other plugins that have isolated=false.
 #
 # Do not disable this unless this plugin depends on another plugin!
-isolated=true
+isolated=false


### PR DESCRIPTION
Since this plugin is providing pipeline functions, it needs to see other plugins, which is what `isolated=true` prevents.

Fixes https://github.com/Graylog2/graylog2-server/issues/2978