### PR TITLE
Making parameter name consistent so it can be passed through.

### DIFF
--- a/src/main/java/org/graylog/plugins/threatintel/functions/global/GlobalIpLookupFunction.java
+++ b/src/main/java/org/graylog/plugins/threatintel/functions/global/GlobalIpLookupFunction.java
@@ -25,7 +25,7 @@ public class GlobalIpLookupFunction extends AbstractGlobalLookupFunction {
     private static final Logger LOG = LoggerFactory.getLogger(GlobalIpLookupFunction.class);
 
     public static final String NAME = "threat_intel_lookup_ip";
-    private static final String VALUE = "ip";
+    private static final String VALUE = "ip_address";
     private static final String PREFIX = "prefix";
 
     private final ParameterDescriptor<String, String> valueParam = ParameterDescriptor.string(VALUE).description("The IPv4 or IPv6 address to look up.").build();


### PR DESCRIPTION
This change makes the parameter name of the `threat_intel_lookup_ip` pipeline function consistent with the other IP-related lookup functions, so the parameters can be passed through to the other functions. Without this change, the other functions would get `null` for their `ip_address` parameters.