### PR TITLE
Use .equals() instead of == for object equality condition

### DIFF
--- a/src/main/java/org/graylog/plugins/threatintel/whois/ip/WhoisDataAdapter.java
+++ b/src/main/java/org/graylog/plugins/threatintel/whois/ip/WhoisDataAdapter.java
@@ -57,7 +57,7 @@ public class WhoisDataAdapter extends LookupDataAdapter {
     protected LookupResult doGet(Object key) {
         try {
             final WhoisIpLookupResult result = this.whoisIpLookup.run(key.toString());
-            if (result != WhoisIpLookupResult.empty()) {
+            if (!WhoisIpLookupResult.empty().equals(result)) {
                 final Map<Object, Object> fields = ImmutableMap.of(
                         ORGANIZATION_FIELD, result.getOrganization(),
                         COUNTRY_CODE_FIELD, result.getCountryCode()


### PR DESCRIPTION
This should be cherry-picked into 2.4 as well.