### PR TITLE
Fix OTX and Whois data adapter issues

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,11 @@
             <version>3.6</version>
         </dependency>
         <dependency>
+            <groupId>commons-validator</groupId>
+            <artifactId>commons-validator</artifactId>
+            <version>1.6</version>
+        </dependency>
+        <dependency>
             <groupId>com.google.auto.value</groupId>
             <artifactId>auto-value</artifactId>
             <version>${auto-value.version}</version>

--- a/src/main/java/org/graylog/plugins/threatintel/ThreatIntelPluginConfiguration.java
+++ b/src/main/java/org/graylog/plugins/threatintel/ThreatIntelPluginConfiguration.java
@@ -14,9 +14,11 @@ import javax.annotation.Nullable;
 public abstract class ThreatIntelPluginConfiguration {
 
     @JsonProperty("otx_enabled")
+    @Deprecated // Not used anymore
     public abstract boolean otxEnabled();
 
     @JsonProperty("otx_api_key")
+    @Deprecated // Only used to migrate API key from pre-2.4 setups
     @Nullable
     public abstract String otxApiKey();
 
@@ -59,8 +61,10 @@ public abstract class ThreatIntelPluginConfiguration {
 
     @AutoValue.Builder
     public static abstract class Builder {
+        @Deprecated
         public abstract Builder otxEnabled(boolean otxEnabled);
 
+        @Deprecated
         abstract Builder otxApiKey(String otxApiKey);
 
         public abstract Builder torEnabled(boolean torEnabled);

--- a/src/main/java/org/graylog/plugins/threatintel/ThreatIntelPluginModule.java
+++ b/src/main/java/org/graylog/plugins/threatintel/ThreatIntelPluginModule.java
@@ -6,6 +6,7 @@ import com.google.inject.TypeLiteral;
 import com.google.inject.multibindings.MapBinder;
 import org.graylog.plugins.pipelineprocessor.ast.functions.Function;
 import org.graylog.plugins.threatintel.adapters.abusech.AbuseChRansomAdapter;
+import org.graylog.plugins.threatintel.adapters.otx.OTXDataAdapter;
 import org.graylog.plugins.threatintel.functions.DomainFunctions;
 import org.graylog.plugins.threatintel.functions.IPFunctions;
 import org.graylog.plugins.threatintel.migrations.V20170815111700_CreateThreatIntelLookupTables;
@@ -71,6 +72,7 @@ public class ThreatIntelPluginModule extends PluginModule {
         installLookupDataAdapter(SpamhausEDROPDataAdapter.NAME, SpamhausEDROPDataAdapter.class, SpamhausEDROPDataAdapter.Factory.class, SpamhausEDROPDataAdapter.Config.class);
         installLookupDataAdapter(TorExitNodeDataAdapter.NAME, TorExitNodeDataAdapter.class, TorExitNodeDataAdapter.Factory.class, TorExitNodeDataAdapter.Config.class);
         installLookupDataAdapter(WhoisDataAdapter.NAME, WhoisDataAdapter.class, WhoisDataAdapter.Factory.class, WhoisDataAdapter.Config.class);
+        installLookupDataAdapter(OTXDataAdapter.NAME, OTXDataAdapter.class, OTXDataAdapter.Factory.class, OTXDataAdapter.Config.class);
 
         addMigration(V20170815111700_CreateThreatIntelLookupTables.class);
         addMigration(V20170821100300_MigrateOTXAPIToken.class);

--- a/src/main/java/org/graylog/plugins/threatintel/adapters/otx/OTXDataAdapter.java
+++ b/src/main/java/org/graylog/plugins/threatintel/adapters/otx/OTXDataAdapter.java
@@ -26,8 +26,6 @@ import okhttp3.Response;
 import okhttp3.ResponseBody;
 import org.apache.commons.validator.routines.InetAddressValidator;
 import org.graylog.autovalue.WithBeanGetter;
-import org.graylog.plugins.threatintel.PluginConfigService;
-import org.graylog.plugins.threatintel.tools.AdapterDisabledException;
 import org.graylog2.plugin.lookup.LookupCachePurge;
 import org.graylog2.plugin.lookup.LookupDataAdapter;
 import org.graylog2.plugin.lookup.LookupDataAdapterConfiguration;
@@ -85,7 +83,6 @@ public class OTXDataAdapter extends LookupDataAdapter {
             .build();
 
     private final Config config;
-    private final PluginConfigService pluginConfigService;
     private final OkHttpClient httpClient;
     private final Timer httpRequestTimer;
     private final Meter httpRequestErrors;
@@ -95,7 +92,6 @@ public class OTXDataAdapter extends LookupDataAdapter {
     protected OTXDataAdapter(@Assisted("id") String id,
                              @Assisted("name") String name,
                              @Assisted LookupDataAdapterConfiguration config,
-                             PluginConfigService pluginConfigService,
                              OkHttpClient httpClient,
                              MetricRegistry metricRegistry) {
         super(id, name, config, metricRegistry);
@@ -106,7 +102,6 @@ public class OTXDataAdapter extends LookupDataAdapter {
                 .writeTimeout(this.config.httpWriteTimeout(), TimeUnit.MILLISECONDS)
                 .readTimeout(this.config.httpReadTimeout(), TimeUnit.MILLISECONDS)
                 .build();
-        this.pluginConfigService = pluginConfigService;
 
         this.httpRequestTimer = metricRegistry.timer(MetricRegistry.name(getClass(), "httpRequestTime"));
         this.httpRequestErrors = metricRegistry.meter(MetricRegistry.name(getClass(), "httpRequestErrors"));
@@ -114,10 +109,6 @@ public class OTXDataAdapter extends LookupDataAdapter {
 
     @Override
     protected void doStart() throws Exception {
-        if (!pluginConfigService.config().getCurrent().otxEnabled()) {
-            throw new AdapterDisabledException("AlienVault OTX service is disabled, not starting OTX adapter. To enable it please go to System / Configurations.");
-        }
-
         final Headers.Builder builder = new Headers.Builder();
 
         final String apiKey = config.apiKey();

--- a/src/main/java/org/graylog/plugins/threatintel/adapters/otx/OTXDataAdapter.java
+++ b/src/main/java/org/graylog/plugins/threatintel/adapters/otx/OTXDataAdapter.java
@@ -1,0 +1,412 @@
+package org.graylog.plugins.threatintel.adapters.otx;
+
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.auto.value.AutoValue;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Multimap;
+import com.google.inject.assistedinject.Assisted;
+import okhttp3.Headers;
+import okhttp3.HttpUrl;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+import org.apache.commons.validator.routines.InetAddressValidator;
+import org.graylog.autovalue.WithBeanGetter;
+import org.graylog.plugins.threatintel.PluginConfigService;
+import org.graylog.plugins.threatintel.tools.AdapterDisabledException;
+import org.graylog2.plugin.lookup.LookupCachePurge;
+import org.graylog2.plugin.lookup.LookupDataAdapter;
+import org.graylog2.plugin.lookup.LookupDataAdapterConfiguration;
+import org.graylog2.plugin.lookup.LookupResult;
+import org.joda.time.Duration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+import javax.inject.Inject;
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotEmpty;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import static com.google.common.base.Strings.isNullOrEmpty;
+
+public class OTXDataAdapter extends LookupDataAdapter {
+    public static final String NAME = "otx-api";
+
+    private static final Logger LOG = LoggerFactory.getLogger(OTXDataAdapter.class);
+    private static final InetAddressValidator INET_ADDRESS_VALIDATOR = InetAddressValidator.getInstance();
+    // Don't use the object mapper from ObjectMapperProvider to make sure we are not affected by changes in that one
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final TypeReference<Map<Object, Object>> MAP_TYPE_REFERENCE = new TypeReference<Map<Object, Object>>() {
+    };
+
+    private static final String OTX_INDICATOR_IPV4 = "IPv4";
+    private static final String OTX_INDICATOR_IPV6 = "IPv6";
+    // The IP indicator is not an official OTX indicator - if this is used we do IPv4/6 auto detection
+    private static final String OTX_INDICATOR_IP_AUTO_DETECT = "IPAutoDetect";
+    private static final ImmutableSet<String> OTX_IP_INDICATORS = ImmutableSet.of(OTX_INDICATOR_IPV4, OTX_INDICATOR_IPV6);
+
+    private static final String OTX_SECTION = "general";
+    private static final ImmutableSet<String> OTX_SCHEMES = ImmutableSet.of("http", "https");
+    private static final ImmutableSet<String> OTX_INDICATORS = ImmutableSet.<String>builder()
+            .add(OTX_INDICATOR_IP_AUTO_DETECT)
+            .add(OTX_INDICATOR_IPV4)
+            .add(OTX_INDICATOR_IPV6)
+            .add("domain")
+            .add("hostname")
+            .add("file")
+            .add("url")
+            .add("cve")
+            .add("nids")
+            .add("correlation-rule")
+            .build();
+
+    private final Config config;
+    private final PluginConfigService pluginConfigService;
+    private final OkHttpClient httpClient;
+    private final Timer httpRequestTimer;
+    private final Meter httpRequestErrors;
+    private Headers httpHeaders;
+
+    @Inject
+    protected OTXDataAdapter(@Assisted("id") String id,
+                             @Assisted("name") String name,
+                             @Assisted LookupDataAdapterConfiguration config,
+                             PluginConfigService pluginConfigService,
+                             OkHttpClient httpClient,
+                             MetricRegistry metricRegistry) {
+        super(id, name, config, metricRegistry);
+
+        this.config = (Config) config;
+        this.httpClient = httpClient.newBuilder() // Copy HTTP client to be able to modify it
+                .connectTimeout(this.config.httpConnectTimeout(), TimeUnit.MILLISECONDS)
+                .writeTimeout(this.config.httpWriteTimeout(), TimeUnit.MILLISECONDS)
+                .readTimeout(this.config.httpReadTimeout(), TimeUnit.MILLISECONDS)
+                .build();
+        this.pluginConfigService = pluginConfigService;
+
+        this.httpRequestTimer = metricRegistry.timer(MetricRegistry.name(getClass(), "httpRequestTime"));
+        this.httpRequestErrors = metricRegistry.meter(MetricRegistry.name(getClass(), "httpRequestErrors"));
+    }
+
+    @Override
+    protected void doStart() throws Exception {
+        if (!pluginConfigService.config().getCurrent().otxEnabled()) {
+            throw new AdapterDisabledException("AlienVault OTX service is disabled, not starting OTX adapter. To enable it please go to System / Configurations.");
+        }
+
+        final Headers.Builder builder = new Headers.Builder();
+
+        final String apiKey = config.apiKey();
+        if (isNullOrEmpty(apiKey)) {
+            LOG.warn("OTX API key is missing. Make sure to add the key to allow higher request limits.");
+        } else {
+            builder.add("X-OTX-API-KEY", apiKey);
+        }
+        if (isNullOrEmpty(config.indicator())) {
+            throw new IllegalArgumentException("OTX indicator is missing");
+        }
+        if (!OTX_INDICATORS.contains(config.indicator())) {
+            throw new IllegalArgumentException("Invalid OTX indicator value - allowed: " + String.join(", ", OTX_INDICATORS));
+        }
+        if (isNullOrEmpty(config.otxHost())) {
+            throw new IllegalArgumentException("OTX host is missing");
+        }
+        if (config.otxPort() < 1) {
+            throw new IllegalArgumentException("OTX port is missing");
+        }
+        if (isNullOrEmpty(config.otxScheme()) || !OTX_SCHEMES.contains(config.otxScheme().toLowerCase(Locale.ENGLISH))) {
+            throw new IllegalArgumentException("OTX scheme value is invalid - allowed: http, https");
+        }
+        if (isNullOrEmpty(config.httpUserAgent())) {
+            throw new IllegalArgumentException("HTTP user-agent is missing");
+        }
+
+        this.httpHeaders = builder
+                .add(HttpHeaders.USER_AGENT, config.httpUserAgent())
+                .add(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON)
+                .build();
+    }
+
+    @Override
+    protected void doStop() throws Exception {
+        // Not needed
+    }
+
+    @Override
+    public Duration refreshInterval() {
+        return Duration.ZERO;
+    }
+
+    @Override
+    protected void doRefresh(LookupCachePurge cachePurge) throws Exception {
+        // Not needed
+    }
+
+    @Override
+    protected LookupResult doGet(Object keyObject) {
+        final String key = String.valueOf(keyObject);
+        String otxIndicator = config.indicator();
+
+        if (OTX_INDICATOR_IP_AUTO_DETECT.equals(otxIndicator)) {
+            // If the indicator is IPAutoDetect, we try to detect the IP address type. If we cannot detect the IP
+            // address type, it is not a valid IP address and we just return an empty result to avoid an unnecessary
+            // HTTP request against the OTX API.
+            final Optional<String> ipType = detectIpType(key);
+            if (ipType.isPresent()) {
+                otxIndicator = ipType.get();
+            } else {
+                LOG.warn("Unable to auto-detect IP address type for key <{}>", key);
+                return LookupResult.empty();
+            }
+        }
+
+        if (OTX_IP_INDICATORS.contains(otxIndicator) && isPrivateIPAddress(key)) {
+            LOG.debug("OTX API does not accept private IP address <{}>. Skipping lookup to avoid OTX API request.", key);
+            return LookupResult.empty();
+        }
+
+        final HttpUrl url = new HttpUrl.Builder()
+                .scheme(config.otxScheme())
+                .host(config.otxHost())
+                .port(config.otxPort())
+                .addPathSegments("/api/v1/indicators")
+                .addPathSegment(otxIndicator)
+                .addPathSegment(String.valueOf(key))
+                .addPathSegment(OTX_SECTION)
+                .build();
+
+        final Request request = new Request.Builder()
+                .get()
+                .url(url)
+                .headers(httpHeaders)
+                .build();
+
+        final Timer.Context time = httpRequestTimer.time();
+        try (final Response response = httpClient.newCall(request).execute()) {
+            if (!response.isSuccessful()) {
+                LOG.warn("OTX {} request for key <{}> failed: {}", otxIndicator, key, response);
+                httpRequestErrors.mark();
+                return LookupResult.empty();
+            }
+
+            return parseResponse(response.body());
+        } catch (IOException e) {
+            LOG.error("OTX {} request error for key <{}>", otxIndicator, key, e);
+            httpRequestErrors.mark();
+            return LookupResult.empty();
+        } finally {
+            time.stop();
+        }
+    }
+
+    @VisibleForTesting
+    @SuppressWarnings("WeakerAccess")
+    LookupResult parseResponse(@Nullable ResponseBody body) {
+        if (body != null) {
+            try {
+                final JsonNode json = OBJECT_MAPPER.readTree(body.string());
+
+                return LookupResult.withoutTTL()
+                        .single(json.path("pulse_info").path("count").asLong(0))
+                        .multiValue(OBJECT_MAPPER.convertValue(json, MAP_TYPE_REFERENCE))
+                        .build();
+            } catch (IOException e) {
+                LOG.warn("Couldn't parse OTX response as JSON", e);
+            }
+        }
+
+        return LookupResult.empty();
+    }
+
+    @VisibleForTesting
+    boolean isPrivateIPAddress(String ip) {
+        try {
+            final InetAddress inetAddress = InetAddress.getByName(ip);
+            return inetAddress.isSiteLocalAddress() || inetAddress.isLoopbackAddress() || inetAddress.isAnyLocalAddress();
+        } catch (UnknownHostException e) {
+            return false;
+        }
+    }
+
+    private Optional<String> detectIpType(String ip) {
+        if (INET_ADDRESS_VALIDATOR.isValidInet4Address(ip)) {
+            return Optional.of(OTX_INDICATOR_IPV4);
+        } else if (INET_ADDRESS_VALIDATOR.isValidInet6Address(ip)) {
+            return Optional.of(OTX_INDICATOR_IPV6);
+        } else {
+            return Optional.empty();
+        }
+    }
+
+    @Override
+    public void set(Object key, Object value) {
+        // Not supported
+    }
+
+    public interface Factory extends LookupDataAdapter.Factory<OTXDataAdapter> {
+        @Override
+        OTXDataAdapter create(@Assisted("id") String id,
+                              @Assisted("name") String name,
+                              LookupDataAdapterConfiguration configuration);
+
+        @Override
+        Descriptor getDescriptor();
+    }
+
+    public static class Descriptor extends LookupDataAdapter.Descriptor<Config> {
+        public Descriptor() {
+            super(NAME, Config.class);
+        }
+
+        @Override
+        public Config defaultConfiguration() {
+            return Config.builder()
+                    .type(NAME)
+                    .indicator(OTX_INDICATOR_IP_AUTO_DETECT)
+                    .otxHost("otx.alienvault.com")
+                    .otxPort(443)
+                    .otxScheme("https")
+                    .httpUserAgent("Graylog Threat Intelligence Plugin - https://github.com/Graylog2/graylog-plugin-threatintel")
+                    .httpConnectTimeout(10000)
+                    .httpWriteTimeout(10000)
+                    .httpReadTimeout(60000)
+                    .build();
+        }
+    }
+
+    @AutoValue
+    @WithBeanGetter
+    @JsonAutoDetect
+    @JsonDeserialize(builder = OTXDataAdapter.Config.Builder.class)
+    @JsonTypeName(NAME)
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public static abstract class Config implements LookupDataAdapterConfiguration {
+        @Override
+        @JsonProperty(TYPE_FIELD)
+        public abstract String type();
+
+        @JsonProperty("indicator")
+        @NotEmpty
+        public abstract String indicator();
+
+        @JsonProperty("api_key")
+        @Nullable
+        public abstract String apiKey();
+
+        @JsonProperty("http_user_agent")
+        @NotEmpty
+        public abstract String httpUserAgent();
+
+        @JsonProperty("otx_host")
+        @NotEmpty
+        public abstract String otxHost();
+
+        @JsonProperty("otx_port")
+        @Min(1)
+        @Max(65535)
+        public abstract int otxPort();
+
+        @JsonProperty("otx_scheme")
+        @NotEmpty
+        public abstract String otxScheme();
+
+        @JsonProperty("http_connect_timeout")
+        @Min(1)
+        public abstract long httpConnectTimeout();
+
+        @JsonProperty("http_write_timeout")
+        @Min(1)
+        public abstract long httpWriteTimeout();
+
+        @JsonProperty("http_read_timeout")
+        @Min(1)
+        public abstract long httpReadTimeout();
+
+        public static Builder builder() {
+            return new AutoValue_OTXDataAdapter_Config.Builder();
+        }
+
+        public abstract Builder toBuilder();
+
+        @Override
+        public Optional<Multimap<String, String>> validate() {
+            final ArrayListMultimap<String, String> errors = ArrayListMultimap.create();
+
+            if (!OTX_INDICATORS.contains(indicator())) {
+                errors.put("indicator", "Invalid value - allowed: " + String.join(", ", OTX_INDICATORS));
+            }
+            if (!OTX_SCHEMES.contains(otxScheme().toLowerCase(Locale.ENGLISH))) {
+                errors.put("otx_scheme", "Invalid value - allowed: " + String.join(", ", OTX_SCHEMES));
+            }
+
+            return errors.isEmpty() ? Optional.empty() : Optional.of(errors);
+        }
+
+        @AutoValue.Builder
+        public abstract static class Builder {
+            @JsonCreator
+            public static Builder create() {
+                return Config.builder()
+                        .httpConnectTimeout(10000)
+                        .httpWriteTimeout(10000)
+                        .httpReadTimeout(60000);
+            }
+
+            @JsonProperty(TYPE_FIELD)
+            public abstract Builder type(String type);
+
+            @JsonProperty("indicator")
+            public abstract Builder indicator(String indicator);
+
+            @JsonProperty("api_key")
+            public abstract Builder apiKey(String apiKey);
+
+            @JsonProperty("http_user_agent")
+            public abstract Builder httpUserAgent(String httpUserAgent);
+
+            @JsonProperty("otx_host")
+            public abstract Builder otxHost(String otxHost);
+
+            @JsonProperty("otx_port")
+            public abstract Builder otxPort(int otxPort);
+
+            @JsonProperty("otx_scheme")
+            public abstract Builder otxScheme(String otxScheme);
+
+            @JsonProperty("http_connect_timeout")
+            public abstract Builder httpConnectTimeout(long httpConnectTimeout);
+
+            @JsonProperty("http_write_timeout")
+            public abstract Builder httpWriteTimeout(long httpWriteTimeout);
+
+            @JsonProperty("http_read_timeout")
+            public abstract Builder httpReadTimeout(long httpReadTimeout);
+
+            public abstract Config build();
+        }
+    }
+}

--- a/src/main/java/org/graylog/plugins/threatintel/functions/otx/AbstractOTXLookupFunction.java
+++ b/src/main/java/org/graylog/plugins/threatintel/functions/otx/AbstractOTXLookupFunction.java
@@ -11,15 +11,27 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 abstract class AbstractOTXLookupFunction extends LookupTableFunction<OTXLookupResult> {
-    private static final String LOOKUP_TABLE_NAME = "otx-ip";
-    private final LookupTableService.Function lookupFunction;
+    private static final String IP_LOOKUP_TABLE_NAME = "otx-api-ip";
+    private static final String DOMAIN_LOOKUP_TABLE_NAME = "otx-api-domain";
+    private final LookupTableService.Function ipLookupFunction;
+    private final LookupTableService.Function domainLookupFunction;
 
     AbstractOTXLookupFunction(final LookupTableService lookupTableService) {
-        this.lookupFunction = lookupTableService.newBuilder().lookupTable(LOOKUP_TABLE_NAME).build();
+        this.ipLookupFunction = lookupTableService.newBuilder().lookupTable(IP_LOOKUP_TABLE_NAME).build();
+        this.domainLookupFunction = lookupTableService.newBuilder().lookupTable(DOMAIN_LOOKUP_TABLE_NAME).build();
     }
 
-    OTXLookupResult lookupIntel(String entity, String type) {
-        final LookupResult lookupResult = this.lookupFunction.lookup(type + "/" + entity);
+    protected OTXLookupResult lookupIP(final String ip) {
+        return lookupIntel(ip, ipLookupFunction);
+    }
+
+    protected OTXLookupResult lookupDomain(final String domain) {
+        return lookupIntel(domain, ipLookupFunction);
+    }
+
+    private OTXLookupResult lookupIntel(final String key, final LookupTableService.Function lookupFunction) {
+        final LookupResult lookupResult = lookupFunction.lookup(key);
+
         if (lookupResult != null && !lookupResult.isEmpty()) {
             final ImmutableMap.Builder<String, Object> result = ImmutableMap.builder();
             final Object singleValue = lookupResult.singleValue();

--- a/src/main/java/org/graylog/plugins/threatintel/functions/otx/OTXDomainLookupFunction.java
+++ b/src/main/java/org/graylog/plugins/threatintel/functions/otx/OTXDomainLookupFunction.java
@@ -37,7 +37,7 @@ public class OTXDomainLookupFunction extends AbstractOTXLookupFunction {
         }
 
         LOG.debug("Running OTX lookup for domain [{}].", domain);
-        return lookupIntel("domain", Domain.prepareDomain(domain).trim());
+        return lookupDomain(Domain.prepareDomain(domain).trim());
     }
 
     @Override

--- a/src/main/java/org/graylog/plugins/threatintel/functions/otx/OTXIPLookupFunction.java
+++ b/src/main/java/org/graylog/plugins/threatintel/functions/otx/OTXIPLookupFunction.java
@@ -38,7 +38,7 @@ public class OTXIPLookupFunction extends AbstractOTXLookupFunction {
 
         LOG.debug("Running OTX lookup for IP [{}].", ip);
 
-        return lookupIntel(ip.trim(), detectIpType(ip.trim()));
+        return lookupIP(ip.trim());
     }
 
     @Override
@@ -49,22 +49,5 @@ public class OTXIPLookupFunction extends AbstractOTXLookupFunction {
                 .params(valueParam)
                 .returnType(OTXLookupResult.class)
                 .build();
-    }
-
-    private String detectIpType(String ip) {
-        /*
-         * This is gonna be super stupid but the user can pass anything in here and trying to recognize IPv4 by a
-         * regular expression just costs a lot of CPU cycles. We trust the user to pass in either IPv4 or IPv6 and
-         * if he/she puts something else in here, it's not our problem. ¯\_(ツ)_/¯
-         */
-        if(ip.contains(".")) {
-            return "IPv4";
-        }
-
-        /*
-         * If it's not IPv4, we just expect it to be IPv6. OTX API will return
-         * simply no results if its any artificial string.
-         */
-        return "IPv6";
     }
 }

--- a/src/main/java/org/graylog/plugins/threatintel/migrations/V20170821100300_MigrateOTXAPIToken.java
+++ b/src/main/java/org/graylog/plugins/threatintel/migrations/V20170821100300_MigrateOTXAPIToken.java
@@ -4,28 +4,31 @@ import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableSet;
 import org.graylog.autovalue.WithBeanGetter;
 import org.graylog.plugins.threatintel.ThreatIntelPluginConfiguration;
+import org.graylog.plugins.threatintel.adapters.otx.OTXDataAdapter;
 import org.graylog2.events.ClusterEventBus;
-import org.graylog2.lookup.adapters.HTTPJSONPathDataAdapter;
 import org.graylog2.lookup.db.DBDataAdapterService;
 import org.graylog2.lookup.dto.DataAdapterDto;
 import org.graylog2.lookup.events.DataAdaptersUpdated;
 import org.graylog2.migrations.Migration;
 import org.graylog2.plugin.cluster.ClusterConfigService;
+import org.graylog2.plugin.lookup.LookupDataAdapterConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nullable;
 import javax.inject.Inject;
 import java.time.ZonedDateTime;
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static com.google.common.base.Strings.isNullOrEmpty;
 
 public class V20170821100300_MigrateOTXAPIToken extends Migration {
     private static final Logger LOG = LoggerFactory.getLogger(V20170821100300_MigrateOTXAPIToken.class);
-    private static final String OTX_DATA_ADAPTER_NAME = "otx-ip";
+    private static final ImmutableSet<String> OTX_DATA_ADAPTER_NAMES = ImmutableSet.of("otx-api-ip", "otx-api-domain");
 
     private final ClusterConfigService clusterConfigService;
     private final DBDataAdapterService dbDataAdapterService;
@@ -53,41 +56,46 @@ public class V20170821100300_MigrateOTXAPIToken extends Migration {
         }
 
         final ThreatIntelPluginConfiguration pluginConfig = clusterConfigService.get(ThreatIntelPluginConfiguration.class);
-        if (pluginConfig == null || pluginConfig.otxApiKey() == null) {
+        if (pluginConfig == null || isNullOrEmpty(pluginConfig.otxApiKey())) {
+            LOG.debug("No existing OTX API key found, not running migration.");
             clusterConfigService.write(MigrationCompleted.notConvertedKey());
             return;
         }
 
         final String otxApiKey = pluginConfig.otxApiKey();
-        final DataAdapterDto dataAdapterDto = this.dbDataAdapterService.get(OTX_DATA_ADAPTER_NAME)
-                .orElseThrow(() -> new IllegalStateException("OTX data adapter not present when trying to add API token."));
 
-        if (dataAdapterDto.config() == null || dataAdapterDto.config().type().equals(HTTPJSONPathDataAdapter.NAME)) {
-            throw new IllegalStateException("AlienVault OTX Data Adapter <" + OTX_DATA_ADAPTER_NAME + "> does not contain config or config has wrong type.");
+        final Set<String> updatedAdapterIds = OTX_DATA_ADAPTER_NAMES.stream()
+                .map(name -> updateAdapter(name, otxApiKey))
+                .collect(Collectors.toSet());
+
+        clusterConfigService.write(MigrationCompleted.convertedKey(updatedAdapterIds));
+    }
+
+    private String updateAdapter(String name, String otxApiKey) {
+        final DataAdapterDto dataAdapterDto = dbDataAdapterService.get(name)
+                .orElseThrow(() -> new IllegalStateException("OTX data adapter <" + name + "> not present when trying to add API token."));
+
+        final LookupDataAdapterConfiguration adapterConfig = dataAdapterDto.config();
+        if (adapterConfig == null || !(adapterConfig instanceof OTXDataAdapter.Config)) {
+            throw new IllegalStateException("OTX Data Adapter <" + name + "> does not contain config or config has wrong type.");
         }
 
-        final HTTPJSONPathDataAdapter.Config config = (HTTPJSONPathDataAdapter.Config)dataAdapterDto.config();
-        final Map<String, String> headers = config.headers();
-        final Map<String, String> newHeaders = new HashMap<>(headers != null ? headers : Collections.emptyMap());
-        newHeaders.put("X-OTX-API-KEY", otxApiKey);
-        final HTTPJSONPathDataAdapter.Config.Builder updatedConfigBuilder = HTTPJSONPathDataAdapter.Config.builder()
-                .type(config.type())
-                .singleValueJSONPath(config.singleValueJSONPath())
-                .url(config.url())
-                .userAgent(config.userAgent())
-                .headers(newHeaders);
-        config.multiValueJSONPath().ifPresent(updatedConfigBuilder::multiValueJSONPath);
+        final OTXDataAdapter.Config config = (OTXDataAdapter.Config) adapterConfig;
 
-        final DataAdapterDto saved = dbDataAdapterService.save(DataAdapterDto.builder()
+        final DataAdapterDto newDto = DataAdapterDto.builder()
                 .id(dataAdapterDto.id())
-                .config(updatedConfigBuilder.build())
+                .config(config.toBuilder().apiKey(otxApiKey).build())
+                .title(dataAdapterDto.title())
                 .description(dataAdapterDto.description())
                 .name(dataAdapterDto.name())
                 .contentPack(dataAdapterDto.contentPack())
-                .build());
+                .build();
+
+        final DataAdapterDto saved = dbDataAdapterService.save(newDto);
 
         clusterBus.post(DataAdaptersUpdated.create(saved.id()));
-        clusterConfigService.write(MigrationCompleted.convertedKey(dataAdapterDto.id()));
+
+        return saved.id();
     }
 
     @JsonAutoDetect
@@ -95,24 +103,23 @@ public class V20170821100300_MigrateOTXAPIToken extends Migration {
     @WithBeanGetter
     public static abstract class MigrationCompleted {
         @JsonProperty("converted_otx_api_key")
-        public abstract Boolean convertedOTXAPIKey();
+        public abstract boolean convertedOTXAPIKey();
 
-        @JsonProperty("data_adapter_id")
-        @Nullable
-        public abstract String dataAdapterId();
+        @JsonProperty("data_adapter_ids")
+        public abstract Set<String> dataAdapterIds();
 
         @JsonCreator
-        public static MigrationCompleted create(@JsonProperty("data_adapter_id") @Nullable final String dataAdapterId,
-                                                @JsonProperty("converted_otx_api_key") final Boolean convertedOTXAPIKey) {
-            return new AutoValue_V20170821100300_MigrateOTXAPIToken_MigrationCompleted(convertedOTXAPIKey, dataAdapterId);
+        public static MigrationCompleted create(@JsonProperty("data_adapter_ids") final Set<String> dataAdapterIds,
+                                                @JsonProperty("converted_otx_api_key") final boolean convertedOTXAPIKey) {
+            return new AutoValue_V20170821100300_MigrateOTXAPIToken_MigrationCompleted(convertedOTXAPIKey, dataAdapterIds);
         }
 
-        public static MigrationCompleted convertedKey(@JsonProperty("data_adapter_id") final String dataAdapterId) {
-            return create(dataAdapterId, true);
+        public static MigrationCompleted convertedKey(@JsonProperty("data_adapter_ids") final Set<String> dataAdapterIds) {
+            return create(dataAdapterIds, true);
         }
 
         public static MigrationCompleted notConvertedKey() {
-            return create(null, false);
+            return create(Collections.emptySet(), false);
         }
     }
 }

--- a/src/main/java/org/graylog/plugins/threatintel/tools/Domain.java
+++ b/src/main/java/org/graylog/plugins/threatintel/tools/Domain.java
@@ -2,16 +2,16 @@ package org.graylog.plugins.threatintel.tools;
 
 public class Domain {
 
-    public static String prepareDomain(String domain) {
+    public static String prepareDomain(final String domain) {
         // A typical issue is regular expressions that also capture a whitespace at the beginning or the end.
-        domain = domain.trim();
+        String trimmedDomain = domain.trim();
 
         // Some systems will capture DNS requests with a trailing '.'. Remove that for the lookup.
-        if(domain.endsWith(".")) {
-            domain = domain.substring(0, domain.length()-1);
+        if(trimmedDomain.endsWith(".")) {
+            trimmedDomain = trimmedDomain.substring(0, trimmedDomain.length()-1);
         }
 
-        return domain;
+        return trimmedDomain;
     }
 
 }

--- a/src/main/java/org/graylog/plugins/threatintel/whois/ip/WhoisDataAdapter.java
+++ b/src/main/java/org/graylog/plugins/threatintel/whois/ip/WhoisDataAdapter.java
@@ -2,6 +2,7 @@ package org.graylog.plugins.threatintel.whois.ip;
 
 import com.codahale.metrics.MetricRegistry;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -33,7 +34,7 @@ public class WhoisDataAdapter extends LookupDataAdapter {
                             @Assisted LookupDataAdapterConfiguration config,
                             MetricRegistry metricRegistry) {
         super(id, name, config, metricRegistry);
-        this.whoisIpLookup = new WhoisIpLookup(((Config) config).registry());
+        this.whoisIpLookup = new WhoisIpLookup((Config) config, metricRegistry);
     }
 
     @Override
@@ -96,6 +97,8 @@ public class WhoisDataAdapter extends LookupDataAdapter {
             return WhoisDataAdapter.Config.builder()
                     .type(NAME)
                     .registry(InternetRegistry.ARIN)
+                    .connectTimeout(1000)
+                    .readTimeout(1000)
                     .build();
         }
     }
@@ -103,7 +106,7 @@ public class WhoisDataAdapter extends LookupDataAdapter {
     @AutoValue
     @WithBeanGetter
     @JsonAutoDetect
-    @JsonDeserialize(builder = AutoValue_WhoisDataAdapter_Config.Builder.class)
+    @JsonDeserialize(builder = WhoisDataAdapter.Config.Builder.class)
     @JsonTypeName(NAME)
     public static abstract class Config implements LookupDataAdapterConfiguration {
 
@@ -113,6 +116,12 @@ public class WhoisDataAdapter extends LookupDataAdapter {
 
         @JsonProperty("registry")
         public abstract InternetRegistry registry();
+
+        @JsonProperty("connect_timeout")
+        public abstract int connectTimeout();
+
+        @JsonProperty("read_timeout")
+        public abstract int readTimeout();
 
         public static Builder builder() {
             return new AutoValue_WhoisDataAdapter_Config.Builder();
@@ -125,11 +134,22 @@ public class WhoisDataAdapter extends LookupDataAdapter {
 
         @AutoValue.Builder
         public abstract static class Builder {
+            @JsonCreator
+            public static Builder create() {
+                return Config.builder().connectTimeout(1000).readTimeout(1000);
+            }
+
             @JsonProperty(TYPE_FIELD)
             public abstract Builder type(String type);
 
             @JsonProperty("registry")
             public abstract Builder registry(InternetRegistry registry);
+
+            @JsonProperty("connect_timeout")
+            public abstract Builder connectTimeout(int connectTimeout);
+
+            @JsonProperty("read_timeout")
+            public abstract Builder readTimeout(int readTimeout);
 
             public abstract Config build();
         }

--- a/src/main/resources/org/graylog/plugins/threatintel/migrations/V20170815111700_CreateThreatIntelLookupTables-content_pack.json
+++ b/src/main/resources/org/graylog/plugins/threatintel/migrations/V20170815111700_CreateThreatIntelLookupTables-content_pack.json
@@ -9,11 +9,22 @@
   "grok_patterns": [],
   "lookup_tables": [
     {
-      "title": "AlienVault Open Thread Exchange IP",
+      "title": "Open Thread Exchange (OTX) - IP",
       "description": "This is the lookup table for AlienVault's Open Thread Exchange platform, containing crowd-sourced IoCs (Indicators of Compromise). For more information see https://otx.alienvault.com. This lookup table is used internally by Graylog's Threat Intel Plugin. Do not delete it manually.",
-      "name": "alienvault-otx-ip",
-      "cache_name": "otx-ip-cache",
-      "data_adapter_name": "otx-ip",
+      "name": "otx-api-ip",
+      "cache_name": "otx-api-ip-cache",
+      "data_adapter_name": "otx-api-ip",
+      "default_single_value": "",
+      "default_single_value_type": "NULL",
+      "default_multi_value": "",
+      "default_multi_value_type": "NULL"
+    },
+    {
+      "title": "Open Thread Exchange (OTX) - Domain",
+      "description": "This is the lookup table for AlienVault's Open Thread Exchange platform, containing crowd-sourced IoCs (Indicators of Compromise). For more information see https://otx.alienvault.com. This lookup table is used internally by Graylog's Threat Intel Plugin. Do not delete it manually.",
+      "name": "otx-api-domain",
+      "cache_name": "otx-api-domain-cache",
+      "data_adapter_name": "otx-api-domain",
       "default_single_value": "",
       "default_single_value_type": "NULL",
       "default_multi_value": "",
@@ -85,9 +96,22 @@
       }
     },
     {
-      "title": "AlienVault Open Threat Exchange IP Cache",
+      "title": "Open Threat Exchange (OTX) - IP Cache",
       "description": "This is the cache for AlienVault's Open Thread Exchange platform, containing crowd-sourced IoCs (Indicators of Compromise). For more information see https://otx.alienvault.com. This cache is used internally by Graylog's Threat Intel Plugin. Do not delete it manually.",
-      "name": "otx-ip-cache",
+      "name": "otx-api-ip-cache",
+      "config": {
+        "type": "guava_cache",
+        "max_size": 1000,
+        "expire_after_access": 0,
+        "expire_after_access_unit": "SECONDS",
+        "expire_after_write": 60,
+        "expire_after_write_unit": "SECONDS"
+      }
+    },
+    {
+      "title": "Open Threat Exchange (OTX) - Domain Cache",
+      "description": "This is the cache for AlienVault's Open Thread Exchange platform, containing crowd-sourced IoCs (Indicators of Compromise). For more information see https://otx.alienvault.com. This cache is used internally by Graylog's Threat Intel Plugin. Do not delete it manually.",
+      "name": "otx-api-domain-cache",
       "config": {
         "type": "guava_cache",
         "max_size": 1000,
@@ -126,18 +150,29 @@
   ],
   "lookup_data_adapters": [
     {
-      "title": "AlienVault Open Thread Exchange IP",
+      "title": "Open Thread Exchange (OTX) - IP",
       "description": "This is the data adapter for AlienVault's Open Thread Exchange platform, containing crowd-sourced IoCs (Indicators of Compromise). For more information see https://otx.alienvault.com. This adapter is used internally by Graylog's Threat Intel Plugin. Do not delete it manually.",
-      "name": "otx-ip",
+      "name": "otx-api-ip",
       "config": {
-        "type": "httpjsonpath",
-        "url": "https://otx.alienvault.com/api/v1/indicators/${key}/general",
-        "single_value_jsonpath": "$.reputation",
-        "multi_value_jsonpath": "$",
-        "user_agent": "Graylog Lookup - https://www.graylog.org/",
-        "headers": {
-          "X-OTX-API-KEY": "<Enter your API key here>"
-        }
+        "type": "otx-api",
+        "indicator": "IPAutoDetect",
+        "http_user_agent": "Graylog Threat Intelligence Plugin - https://github.com/Graylog2/graylog-plugin-threatintel",
+        "otx_host": "otx.alienvault.com",
+        "otx_port": "443",
+        "otx_scheme": "https"
+      }
+    },
+    {
+      "title": "Open Thread Exchange (OTX) - Domain",
+      "description": "This is the data adapter for AlienVault's Open Thread Exchange platform, containing crowd-sourced IoCs (Indicators of Compromise). For more information see https://otx.alienvault.com. This adapter is used internally by Graylog's Threat Intel Plugin. Do not delete it manually.",
+      "name": "otx-api-domain",
+      "config": {
+        "type": "otx-api",
+        "indicator": "domain",
+        "http_user_agent": "Graylog Threat Intelligence Plugin - https://github.com/Graylog2/graylog-plugin-threatintel",
+        "otx_host": "otx.alienvault.com",
+        "otx_port": "443",
+        "otx_scheme": "https"
       }
     },
     {

--- a/src/main/resources/org/graylog/plugins/threatintel/migrations/V20170815111700_CreateThreatIntelLookupTables-content_pack.json
+++ b/src/main/resources/org/graylog/plugins/threatintel/migrations/V20170815111700_CreateThreatIntelLookupTables-content_pack.json
@@ -156,10 +156,8 @@
       "config": {
         "type": "otx-api",
         "indicator": "IPAutoDetect",
-        "http_user_agent": "Graylog Threat Intelligence Plugin - https://github.com/Graylog2/graylog-plugin-threatintel",
-        "otx_host": "otx.alienvault.com",
-        "otx_port": "443",
-        "otx_scheme": "https"
+        "api_url": "https://otx.alienvault.com",
+        "http_user_agent": "Graylog Threat Intelligence Plugin - https://github.com/Graylog2/graylog-plugin-threatintel"
       }
     },
     {
@@ -169,10 +167,8 @@
       "config": {
         "type": "otx-api",
         "indicator": "domain",
-        "http_user_agent": "Graylog Threat Intelligence Plugin - https://github.com/Graylog2/graylog-plugin-threatintel",
-        "otx_host": "otx.alienvault.com",
-        "otx_port": "443",
-        "otx_scheme": "https"
+        "api_url": "https://otx.alienvault.com",
+        "http_user_agent": "Graylog Threat Intelligence Plugin - https://github.com/Graylog2/graylog-plugin-threatintel"
       }
     },
     {

--- a/src/test/java/org/graylog/plugins/threatintel/adapters/otx/OTXDataAdapterTest.java
+++ b/src/test/java/org/graylog/plugins/threatintel/adapters/otx/OTXDataAdapterTest.java
@@ -4,12 +4,10 @@ import com.codahale.metrics.MetricRegistry;
 import com.google.common.io.Resources;
 import okhttp3.OkHttpClient;
 import okhttp3.ResponseBody;
-import org.graylog.plugins.threatintel.PluginConfigService;
 import org.graylog2.plugin.lookup.LookupResult;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
@@ -21,8 +19,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class OTXDataAdapterTest {
     @Rule
     public final MockitoRule mockitoRule = MockitoJUnit.rule();
-    @Mock
-    private PluginConfigService pluginConfigService;
 
     private OTXDataAdapter otxDataAdapter;
 
@@ -31,7 +27,7 @@ public class OTXDataAdapterTest {
         final OTXDataAdapter.Config defaultConfiguration = new OTXDataAdapter.Descriptor().defaultConfiguration();
         final MetricRegistry metricRegistry = new MetricRegistry();
 
-        this.otxDataAdapter = new OTXDataAdapter("1", "otx-test", defaultConfiguration, pluginConfigService, new OkHttpClient(), metricRegistry);
+        this.otxDataAdapter = new OTXDataAdapter("1", "otx-test", defaultConfiguration, new OkHttpClient(), metricRegistry);
     }
 
     @Test

--- a/src/test/java/org/graylog/plugins/threatintel/adapters/otx/OTXDataAdapterTest.java
+++ b/src/test/java/org/graylog/plugins/threatintel/adapters/otx/OTXDataAdapterTest.java
@@ -1,0 +1,57 @@
+package org.graylog.plugins.threatintel.adapters.otx;
+
+import com.codahale.metrics.MetricRegistry;
+import com.google.common.io.Resources;
+import okhttp3.OkHttpClient;
+import okhttp3.ResponseBody;
+import org.graylog.plugins.threatintel.PluginConfigService;
+import org.graylog2.plugin.lookup.LookupResult;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import java.net.URL;
+
+import static java.util.Objects.requireNonNull;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class OTXDataAdapterTest {
+    @Rule
+    public final MockitoRule mockitoRule = MockitoJUnit.rule();
+    @Mock
+    private PluginConfigService pluginConfigService;
+
+    private OTXDataAdapter otxDataAdapter;
+
+    @Before
+    public void setUp() throws Exception {
+        final OTXDataAdapter.Config defaultConfiguration = new OTXDataAdapter.Descriptor().defaultConfiguration();
+        final MetricRegistry metricRegistry = new MetricRegistry();
+
+        this.otxDataAdapter = new OTXDataAdapter("1", "otx-test", defaultConfiguration, pluginConfigService, new OkHttpClient(), metricRegistry);
+    }
+
+    @Test
+    public void parseResponse() throws Exception {
+        final URL url = Resources.getResource(getClass(), "otx-IPv4-response.json");
+        final ResponseBody body = ResponseBody.create(null, Resources.toByteArray(url));
+        final LookupResult result = otxDataAdapter.parseResponse(body);
+
+        assertThat(result.singleValue()).isEqualTo(0L);
+        assertThat(result.multiValue()).isNotNull();
+        assertThat(requireNonNull(result.multiValue()).get("country_name")).isEqualTo("Ireland");
+    }
+
+    @Test
+    public void isPrivateIPAddress() throws Exception {
+        assertThat(otxDataAdapter.isPrivateIPAddress("0.0.0.0")).isTrue();
+        assertThat(otxDataAdapter.isPrivateIPAddress("127.0.0.1")).isTrue();
+        assertThat(otxDataAdapter.isPrivateIPAddress("192.168.1.1")).isTrue();
+        assertThat(otxDataAdapter.isPrivateIPAddress("192.168.178.56")).isTrue();
+        assertThat(otxDataAdapter.isPrivateIPAddress("8.8.8.8")).isFalse();
+        assertThat(otxDataAdapter.isPrivateIPAddress("137.254.56.25")).isFalse();
+    }
+}

--- a/src/test/resources/org/graylog/plugins/threatintel/adapters/otx/otx-IPv4-response.json
+++ b/src/test/resources/org/graylog/plugins/threatintel/adapters/otx/otx-IPv4-response.json
@@ -1,0 +1,51 @@
+{
+  "sections": [
+    "general",
+    "geo",
+    "reputation",
+    "url_list",
+    "passive_dns",
+    "malware",
+    "nids_list",
+    "http_scans"
+  ],
+  "city": "Dublin",
+  "area_code": 0,
+  "pulse_info": {
+    "count": 0,
+    "references": [],
+    "pulses": []
+  },
+  "continent_code": "EU",
+  "country_name": "Ireland",
+  "postal_code": null,
+  "dma_code": 0,
+  "country_code": "IE",
+  "flag_url": "/static/img/flags/ie.png",
+  "asn": "AS16509 Amazon.com, Inc.",
+  "city_data": true,
+  "indicator": "52.19.0.7",
+  "whois": "http://whois.domaintools.com/52.19.0.7",
+  "type_title": "IPv4",
+  "region": "07",
+  "charset": 0,
+  "longitude": -6.259500026702881,
+  "country_code3": "IRL",
+  "reputation": 0,
+  "base_indicator": {},
+  "latitude": 53.33890151977539,
+  "validation": [
+    {
+      "source": "aws",
+      "message": "In IP range: region=eu-west-1 prefix=52.18.0.0/15 service=AMAZON",
+      "name": "AWS IP range"
+    },
+    {
+      "source": "suspicious",
+      "message": "suspiciously short IP (len: 9)",
+      "name": "Suspicious IP format / Possible version number"
+    }
+  ],
+  "type": "IPv4",
+  "flag_title": "Ireland"
+}

--- a/src/web/components/ThreatIntelPluginConfig.jsx
+++ b/src/web/components/ThreatIntelPluginConfig.jsx
@@ -1,12 +1,10 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Alert, Button } from 'react-bootstrap';
-import { LinkContainer } from 'react-router-bootstrap';
+import { Button } from 'react-bootstrap';
 
 import { BootstrapModalForm, Input } from 'components/bootstrap';
 import { IfPermitted } from 'components/common';
 import ObjectUtils from 'util/ObjectUtils';
-import Routes from 'routing/Routes';
 
 const ThreatIntelPluginConfig = React.createClass({
   propTypes: {

--- a/src/web/components/ThreatIntelPluginConfig.jsx
+++ b/src/web/components/ThreatIntelPluginConfig.jsx
@@ -17,7 +17,6 @@ const ThreatIntelPluginConfig = React.createClass({
   getDefaultProps() {
     return {
       config: {
-        otx_enabled: false,
         tor_enabled: false,
         spamhaus_enabled: false,
         abusech_ransom_enabled: false,
@@ -96,9 +95,6 @@ const ThreatIntelPluginConfig = React.createClass({
 
           <dt>Abuse.ch Ransomware:</dt>
           <dd>{this.state.config.abusech_ransom_enabled === true ? 'Enabled' : 'Disabled'}</dd>
-
-          <dt>AlienVault OTX:</dt>
-          <dd>{this.state.config.otx_enabled === true ? 'Enabled' : 'Disabled'}</dd>
         </dl>
 
         <IfPermitted permissions="clusterconfigentry:edit">
@@ -137,15 +133,6 @@ const ThreatIntelPluginConfig = React.createClass({
                    name="tor_enabled"
                    checked={this.state.config.abusech_ransom_enabled}
                    onChange={this._onCheckboxClick('abusech_ransom_enabled', 'abusechRansomEnabled')}/>
-
-            <Input type="checkbox"
-                   id="otx-checkbox"
-                   ref="otxEnabled"
-                   label="Allow AlienVault OTX lookups?"
-                   help="Enable to include AlienVault OTX lookup in global pipeline function."
-                   name="otx_enabled"
-                   checked={this.state.config.otx_enabled}
-                   onChange={this._onCheckboxClick('otx_enabled', 'otxEnabled')}/>
           </fieldset>
         </BootstrapModalForm>
       </div>

--- a/src/web/components/ThreatIntelPluginConfig.jsx
+++ b/src/web/components/ThreatIntelPluginConfig.jsx
@@ -146,12 +146,6 @@ const ThreatIntelPluginConfig = React.createClass({
                    name="otx_enabled"
                    checked={this.state.config.otx_enabled}
                    onChange={this._onCheckboxClick('otx_enabled', 'otxEnabled')}/>
-
-            <Alert>
-              Please take note that the <i>AlienVault OTX API token</i> is not managed on this page anymore.
-              Instead you have to add an <code>X-OTX-API-KEY</code> header containing your personal API token for the
-              corresponding data adapter over <LinkContainer to={Routes.SYSTEM.LOOKUPTABLES.DATA_ADAPTERS.edit('otx-ip')}><span>here</span></LinkContainer>.
-            </Alert>
           </fieldset>
         </BootstrapModalForm>
       </div>

--- a/src/web/components/adapters/otx/OTXAdapterDocumentation.jsx
+++ b/src/web/components/adapters/otx/OTXAdapterDocumentation.jsx
@@ -34,39 +34,18 @@ const OTXAdapterDocumentation = React.createClass({
           please register for an OTX account and get an API key.</strong>
         </p>
 
+        <h5 style={style}>OTX API URL</h5>
+
+        <p style={style}>
+          HTTP URL of the OTX API server. The default setting of <code>https://otx.alienvault.com</code> should not be changed
+          except if you want to run some tests with a custom server.
+        </p>
+
         <h5 style={style}>HTTP User-Agent</h5>
 
         <p style={style}>
           This will set the <code>User-Agent</code> HTTP header for OTX API requests. You can modify this to include
           your contact details so the OTX API operators can contact you if there are problems with your API requests.
-        </p>
-
-        <hr />
-
-        <p style={style}>
-          The following settings are only useful when you need to contact a different OTX API implementation which
-          should not be needed most of the time.
-        </p>
-
-        <h5 style={style}>OTX Hostname</h5>
-
-        <p style={style}>
-          Hostname of the OTX API server. The default setting of <code>otx.alienvault.com</code> should not be changed
-          except if you want to run some tests with a custom server.
-        </p>
-
-        <h5 style={style}>OTX Port</h5>
-
-        <p style={style}>
-          HTTP port of the OTX API server. The default setting of <code>443</code> should not be changed
-          except if you want to run some tests with a custom server.
-        </p>
-
-        <h5 style={style}>OTX HTTP Scheme</h5>
-
-        <p style={style}>
-          URL scheme for the OTX API server requests. The default setting of <code>HTTPS</code> should not be changed
-          except if you want to run some tests with a custom server.
         </p>
 
         <h5 style={style}>HTTP Connection Timeout</h5>

--- a/src/web/components/adapters/otx/OTXAdapterDocumentation.jsx
+++ b/src/web/components/adapters/otx/OTXAdapterDocumentation.jsx
@@ -1,0 +1,97 @@
+/* eslint-disable react/no-unescaped-entities, no-template-curly-in-string */
+import React from 'react';
+
+import { ExternalLink } from 'components/common';
+
+const OTXAdapterDocumentation = React.createClass({
+  render() {
+    const style = { marginBottom: 10 };
+    return (
+      <div>
+        <p style={style}>
+          The AlienVault OTX data adapter uses the <ExternalLink href="https://otx.alienvault.com/api">OTX API</ExternalLink> to
+          lookup indicators for the given key.
+        </p>
+
+        <h3 style={style}>Configuration</h3>
+
+        <h5 style={style}>Indicator</h5>
+
+        <p style={style}>
+          The OTX API offers several different indicators of compromise (IOCs). You have to select which indicator
+          should be used for this data adapter.
+        </p>
+        <p style={style}>
+          The <code>IP Auto-Detect</code> indicator is not an official one. We added that to make it possible to
+          auto-detect the IP address type to allow using the same data adapter for IP v4 and v6 addresses.
+        </p>
+
+        <h5 style={style}>OTX API Key</h5>
+
+        <p style={style}>
+          The OTX API key is used to authenticate API requests. Requests also work if you don't enter an API key, but
+          you will most probably get a smaller request limit. <strong>If you use this data adapter for production traffic,
+          please register for an OTX account and get an API key.</strong>
+        </p>
+
+        <h5 style={style}>HTTP User-Agent</h5>
+
+        <p style={style}>
+          This will set the <code>User-Agent</code> HTTP header for OTX API requests. You can modify this to include
+          your contact details so the OTX API operators can contact you if there are problems with your API requests.
+        </p>
+
+        <hr />
+
+        <p style={style}>
+          The following settings are only useful when you need to contact a different OTX API implementation which
+          should not be needed most of the time.
+        </p>
+
+        <h5 style={style}>OTX Hostname</h5>
+
+        <p style={style}>
+          Hostname of the OTX API server. The default setting of <code>otx.alienvault.com</code> should not be changed
+          except if you want to run some tests with a custom server.
+        </p>
+
+        <h5 style={style}>OTX Port</h5>
+
+        <p style={style}>
+          HTTP port of the OTX API server. The default setting of <code>443</code> should not be changed
+          except if you want to run some tests with a custom server.
+        </p>
+
+        <h5 style={style}>OTX HTTP Scheme</h5>
+
+        <p style={style}>
+          URL scheme for the OTX API server requests. The default setting of <code>HTTPS</code> should not be changed
+          except if you want to run some tests with a custom server.
+        </p>
+
+        <h5 style={style}>HTTP Connection Timeout</h5>
+
+        <p style={style}>
+          The HTTP connection timeout in milliseconds for the OTX API request. If you set this to a high value and
+          the OTX API connection is slow, processing performance can be affected.
+        </p>
+
+        <h5 style={style}>HTTP Write Timeout</h5>
+
+        <p style={style}>
+          The HTTP write timeout in milliseconds for the OTX API request. If you set this to a high value and
+          the OTX API connection is slow, processing performance can be affected.
+        </p>
+
+        <h5 style={style}>HTTP Read Timeout</h5>
+
+        <p style={style}>
+          The HTTP read timeout in milliseconds for the OTX API request. If you set this to a high value and
+          the OTX API connection is slow, processing performance can be affected.
+        </p>
+      </div>
+    );
+  },
+});
+
+export default OTXAdapterDocumentation;

--- a/src/web/components/adapters/otx/OTXAdapterFieldSet.jsx
+++ b/src/web/components/adapters/otx/OTXAdapterFieldSet.jsx
@@ -1,0 +1,169 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import lodash from 'lodash';
+
+import { Input } from 'components/bootstrap';
+import { Select } from 'components/common';
+
+const OTX_INDICATORS = [
+  { label: 'IP Auto-Detect', value: 'IPAutoDetect' },
+  { label: 'IP v4', value: 'IPv4' },
+  { label: 'IP v6', value: 'IPv6' },
+  { label: 'Domain', value: 'domain' },
+  { label: 'Hostname', value: 'hostname' },
+  { label: 'File', value: 'file' },
+  { label: 'URL', value: 'url' },
+  { label: 'CVE', value: 'cve' },
+  { label: 'NIDS', value: 'nids' },
+  { label: 'Correlation-Rule', value: 'correlation-rule' },
+];
+
+const OTX_HTTP_SCHEMES = [
+  { label: 'HTTPS', value: 'https' },
+  { label: 'HTTP', value: 'http' },
+];
+
+const OTXAdapterFieldSet = React.createClass({
+  propTypes: {
+    config: PropTypes.shape({
+      indicator: PropTypes.string.isRequired,
+      api_key: PropTypes.string,
+      http_user_agent: PropTypes.string.isRequired,
+      otx_host: PropTypes.string.isRequired,
+      otx_port: PropTypes.number.isRequired,
+      otx_scheme: PropTypes.string.isRequired,
+      http_connect_timeout: PropTypes.number.isRequired,
+      http_write_timeout: PropTypes.number.isRequired,
+      http_read_timeout: PropTypes.number.isRequired,
+    }).isRequired,
+    updateConfig: PropTypes.func.isRequired,
+    handleFormEvent: PropTypes.func.isRequired,
+    validationState: PropTypes.func.isRequired,
+    validationMessage: PropTypes.func.isRequired,
+  },
+
+  handleSelect(fieldName) {
+    return (selectedIndicator) => {
+      const config = lodash.cloneDeep(this.props.config);
+      config[fieldName] = selectedIndicator;
+      this.props.updateConfig(config);
+    };
+  },
+
+  render() {
+    const { config } = this.props;
+
+    return (
+      <fieldset>
+        <Input id="indicator"
+               label="Indicator"
+               required
+               onChange={this.props.handleFormEvent}
+               help={this.props.validationMessage('indicator', 'The OTX indicator type that should be used for lookups.')}
+               bsStyle={this.props.validationState('indicator')}
+               labelClassName="col-sm-3"
+               wrapperClassName="col-sm-9">
+          <Select placeholder="Select indicator"
+                  clearable={false}
+                  options={OTX_INDICATORS}
+                  matchProp="value"
+                  onChange={this.handleSelect('indicator')}
+                  value={config.indicator} />
+        </Input>
+        <Input type="text"
+               id="api_key"
+               name="api_key"
+               label="OTX API Key"
+               onChange={this.props.handleFormEvent}
+               help={this.props.validationMessage('api_key', 'Your OTX API key.')}
+               bsStyle={this.props.validationState('api_key')}
+               value={config.api_key}
+               labelClassName="col-sm-3"
+               wrapperClassName="col-sm-9" />
+        <Input type="text"
+               id="http_user_agent"
+               name="http_user_agent"
+               label="HTTP User-Agent"
+               required
+               onChange={this.props.handleFormEvent}
+               help={this.props.validationMessage('http_user_agent', 'The User-Agent header that should be used for the HTTP request.')}
+               bsStyle={this.props.validationState('http_user_agent')}
+               value={config.http_user_agent}
+               labelClassName="col-sm-3"
+               wrapperClassName="col-sm-9" />
+        <Input type="text"
+               id="otx_host"
+               name="otx_host"
+               label="OTX Hostname"
+               required
+               onChange={this.props.handleFormEvent}
+               help={this.props.validationMessage('otx_host', 'Hostname of the OTX server.')}
+               bsStyle={this.props.validationState('otx_host')}
+               value={config.otx_host}
+               labelClassName="col-sm-3"
+               wrapperClassName="col-sm-9" />
+        <Input type="text"
+               id="otx_port"
+               name="otx_port"
+               label="OTX Port"
+               required
+               onChange={this.props.handleFormEvent}
+               help={this.props.validationMessage('otx_port', 'Port for the connection to the server.')}
+               bsStyle={this.props.validationState('otx_port')}
+               value={config.otx_port}
+               labelClassName="col-sm-3"
+               wrapperClassName="col-sm-9" />
+        <Input id="otx_scheme"
+               label="HTTP Scheme"
+               required
+               onChange={this.props.handleFormEvent}
+               help={this.props.validationMessage('otx_scheme', 'The registry used for the initial lookup, should be the closest to your location.')}
+               bsStyle={this.props.validationState('otx_scheme')}
+               labelClassName="col-sm-3"
+               wrapperClassName="col-sm-9">
+          <Select placeholder="Select indicator"
+                  clearable={false}
+                  options={OTX_HTTP_SCHEMES}
+                  matchProp="value"
+                  onChange={this.handleSelect('otx_scheme')}
+                  value={config.otx_scheme} />
+        </Input>
+        <Input type="number"
+               id="http_connect_timeout"
+               name="http_connect_timeout"
+               label="HTTP Connect Timeout"
+               required
+               onChange={this.props.handleFormEvent}
+               help={this.props.validationMessage('http_connect_timeout', 'HTTP connection timeout in milliseconds.')}
+               bsStyle={this.props.validationState('http_connect_timeout')}
+               value={config.http_connect_timeout}
+               labelClassName="col-sm-3"
+               wrapperClassName="col-sm-9" />
+        <Input type="number"
+               id="http_write_timeout"
+               name="http_write_timeout"
+               label="HTTP Write Timeout"
+               required
+               onChange={this.props.handleFormEvent}
+               help={this.props.validationMessage('http_write_timeout', 'HTTP write timeout in milliseconds.')}
+               bsStyle={this.props.validationState('http_write_timeout')}
+               value={config.http_write_timeout}
+               labelClassName="col-sm-3"
+               wrapperClassName="col-sm-9" />
+        <Input type="number"
+               id="http_read_timeout"
+               name="http_read_timeout"
+               label="HTTP Read Timeout"
+               required
+               onChange={this.props.handleFormEvent}
+               help={this.props.validationMessage('http_read_timeout', 'HTTP read timeout in milliseconds.')}
+               bsStyle={this.props.validationState('http_read_timeout')}
+               value={config.http_read_timeout}
+               labelClassName="col-sm-3"
+               wrapperClassName="col-sm-9" />
+      </fieldset>
+    );
+  },
+});
+
+export default OTXAdapterFieldSet;

--- a/src/web/components/adapters/otx/OTXAdapterFieldSet.jsx
+++ b/src/web/components/adapters/otx/OTXAdapterFieldSet.jsx
@@ -18,20 +18,13 @@ const OTX_INDICATORS = [
   { label: 'Correlation-Rule', value: 'correlation-rule' },
 ];
 
-const OTX_HTTP_SCHEMES = [
-  { label: 'HTTPS', value: 'https' },
-  { label: 'HTTP', value: 'http' },
-];
-
 const OTXAdapterFieldSet = React.createClass({
   propTypes: {
     config: PropTypes.shape({
       indicator: PropTypes.string.isRequired,
       api_key: PropTypes.string,
+      api_url: PropTypes.string.isRequired,
       http_user_agent: PropTypes.string.isRequired,
-      otx_host: PropTypes.string.isRequired,
-      otx_port: PropTypes.number.isRequired,
-      otx_scheme: PropTypes.string.isRequired,
       http_connect_timeout: PropTypes.number.isRequired,
       http_write_timeout: PropTypes.number.isRequired,
       http_read_timeout: PropTypes.number.isRequired,
@@ -81,6 +74,16 @@ const OTXAdapterFieldSet = React.createClass({
                labelClassName="col-sm-3"
                wrapperClassName="col-sm-9" />
         <Input type="text"
+               id="api_url"
+               name="api_url"
+               label="OTX API URL"
+               onChange={this.props.handleFormEvent}
+               help={this.props.validationMessage('api_url', 'URL of the OTX API server.')}
+               bsStyle={this.props.validationState('api_url')}
+               value={config.api_url}
+               labelClassName="col-sm-3"
+               wrapperClassName="col-sm-9" />
+        <Input type="text"
                id="http_user_agent"
                name="http_user_agent"
                label="HTTP User-Agent"
@@ -91,43 +94,6 @@ const OTXAdapterFieldSet = React.createClass({
                value={config.http_user_agent}
                labelClassName="col-sm-3"
                wrapperClassName="col-sm-9" />
-        <Input type="text"
-               id="otx_host"
-               name="otx_host"
-               label="OTX Hostname"
-               required
-               onChange={this.props.handleFormEvent}
-               help={this.props.validationMessage('otx_host', 'Hostname of the OTX server.')}
-               bsStyle={this.props.validationState('otx_host')}
-               value={config.otx_host}
-               labelClassName="col-sm-3"
-               wrapperClassName="col-sm-9" />
-        <Input type="text"
-               id="otx_port"
-               name="otx_port"
-               label="OTX Port"
-               required
-               onChange={this.props.handleFormEvent}
-               help={this.props.validationMessage('otx_port', 'Port for the connection to the server.')}
-               bsStyle={this.props.validationState('otx_port')}
-               value={config.otx_port}
-               labelClassName="col-sm-3"
-               wrapperClassName="col-sm-9" />
-        <Input id="otx_scheme"
-               label="HTTP Scheme"
-               required
-               onChange={this.props.handleFormEvent}
-               help={this.props.validationMessage('otx_scheme', 'The registry used for the initial lookup, should be the closest to your location.')}
-               bsStyle={this.props.validationState('otx_scheme')}
-               labelClassName="col-sm-3"
-               wrapperClassName="col-sm-9">
-          <Select placeholder="Select indicator"
-                  clearable={false}
-                  options={OTX_HTTP_SCHEMES}
-                  matchProp="value"
-                  onChange={this.handleSelect('otx_scheme')}
-                  value={config.otx_scheme} />
-        </Input>
         <Input type="number"
                id="http_connect_timeout"
                name="http_connect_timeout"

--- a/src/web/components/adapters/otx/OTXAdapterSummary.jsx
+++ b/src/web/components/adapters/otx/OTXAdapterSummary.jsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const OTXAdapterSummary = React.createClass({
+  propTypes: {
+    dataAdapter: PropTypes.shape({
+      config: PropTypes.shape({
+        indicator: PropTypes.string.isRequired,
+        api_key: PropTypes.string,
+        http_user_agent: PropTypes.string.isRequired,
+        otx_host: PropTypes.string.isRequired,
+        otx_port: PropTypes.number.isRequired,
+        otx_scheme: PropTypes.string.isRequired,
+        http_connect_timeout: PropTypes.number.isRequired,
+        http_write_timeout: PropTypes.number.isRequired,
+        http_read_timeout: PropTypes.number.isRequired,
+      }),
+    }),
+  },
+
+  render() {
+    const { config } = this.props.dataAdapter;
+
+    return (
+      <dl>
+        <dt>Indicator</dt>
+        <dd>{config.indicator}</dd>
+        <dt>OTX API Key</dt>
+        <dd>{config.api_key || 'n/a'}</dd>
+        <dt>HTTP User-Agent</dt>
+        <dd>{config.http_user_agent}</dd>
+        <dt>OTX Hostname</dt>
+        <dd>{config.otx_host}</dd>
+        <dt>OTX Port</dt>
+        <dd>{config.otx_port}</dd>
+        <dt>HTTP Scheme</dt>
+        <dd>{config.otx_scheme}</dd>
+        <dt>HTTP Connect Timeout</dt>
+        <dd>{config.http_connect_timeout} ms</dd>
+        <dt>HTTP Write Timeout</dt>
+        <dd>{config.http_write_timeout} ms</dd>
+        <dt>HTTP Read Timeout</dt>
+        <dd>{config.http_read_timeout} ms</dd>
+      </dl>
+    );
+  },
+});
+
+export default OTXAdapterSummary;

--- a/src/web/components/adapters/otx/OTXAdapterSummary.jsx
+++ b/src/web/components/adapters/otx/OTXAdapterSummary.jsx
@@ -7,10 +7,8 @@ const OTXAdapterSummary = React.createClass({
       config: PropTypes.shape({
         indicator: PropTypes.string.isRequired,
         api_key: PropTypes.string,
+        api_url: PropTypes.string.isRequired,
         http_user_agent: PropTypes.string.isRequired,
-        otx_host: PropTypes.string.isRequired,
-        otx_port: PropTypes.number.isRequired,
-        otx_scheme: PropTypes.string.isRequired,
         http_connect_timeout: PropTypes.number.isRequired,
         http_write_timeout: PropTypes.number.isRequired,
         http_read_timeout: PropTypes.number.isRequired,
@@ -27,14 +25,10 @@ const OTXAdapterSummary = React.createClass({
         <dd>{config.indicator}</dd>
         <dt>OTX API Key</dt>
         <dd>{config.api_key || 'n/a'}</dd>
+        <dt>OTX API URL</dt>
+        <dd>{config.api_url}</dd>
         <dt>HTTP User-Agent</dt>
         <dd>{config.http_user_agent}</dd>
-        <dt>OTX Hostname</dt>
-        <dd>{config.otx_host}</dd>
-        <dt>OTX Port</dt>
-        <dd>{config.otx_port}</dd>
-        <dt>HTTP Scheme</dt>
-        <dd>{config.otx_scheme}</dd>
         <dt>HTTP Connect Timeout</dt>
         <dd>{config.http_connect_timeout} ms</dd>
         <dt>HTTP Write Timeout</dt>

--- a/src/web/components/adapters/otx/index.jsx
+++ b/src/web/components/adapters/otx/index.jsx
@@ -1,0 +1,3 @@
+export { default as OTXAdapterDocumentation } from './OTXAdapterDocumentation';
+export { default as OTXAdapterFieldSet } from './OTXAdapterFieldSet';
+export { default as OTXAdapterSummary } from './OTXAdapterSummary';

--- a/src/web/components/adapters/whois/WhoisAdapterDocumentation.jsx
+++ b/src/web/components/adapters/whois/WhoisAdapterDocumentation.jsx
@@ -1,5 +1,38 @@
 import React from 'react';
 
-const WhoisAdapterDocumentation = () => <div />;
+const WhoisAdapterDocumentation = () => {
+  const style = { marginBottom: 10 };
+
+  return (
+    <div>
+      <p style={style}>
+        The whois IP lookup data adapter can request network ownership information for an IP address.
+      </p>
+
+      <h3 style={style}>Configuration</h3>
+
+      <h5 style={style}>Registry</h5>
+
+      <p style={style}>
+        The whois registry host that should be used for the lookup requests. The default value of <code>ARIN</code> should
+        work in most cases because it is returning redirects to other servers if it cannot answer a request.
+      </p>
+
+      <h5 style={style}>Connect timeout</h5>
+
+      <p style={style}>
+        The connection timeout for the socket to the whois server in milliseconds. If you set this to a
+        high value, it can affect your processing peformance.
+      </p>
+
+      <h5 style={style}>Read timeout</h5>
+
+      <p style={style}>
+        The connection read timeout for the socket to the whois server in milliseconds. If you set this to a
+        high value, it can affect your processing peformance.
+      </p>
+    </div>
+  );
+};
 
 export default WhoisAdapterDocumentation;

--- a/src/web/components/adapters/whois/WhoisAdapterFieldSet.jsx
+++ b/src/web/components/adapters/whois/WhoisAdapterFieldSet.jsx
@@ -1,42 +1,83 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import lodash from 'lodash';
 
 import { Input } from 'components/bootstrap';
+import { Select } from 'components/common';
 
-const Registries = {
-  AFRINIC: 'AFRINIC (Africa)',
-  APNIC: 'APNIC (Asia/Pacific)',
-  ARIN: 'ARIN (North America)',
-  LACNIC: 'LACNIC (South America)',
-  RIPENCC: 'RIPENCC (Europe)',
-};
+const WHOIS_REGISTRIES = [
+  { value: 'AFRINIC', label: 'AFRINIC (Africa)' },
+  { value: 'APNIC', label: 'APNIC (Asia/Pacific)' },
+  { value: 'ARIN', label: 'ARIN (North America)' },
+  { value: 'LACNIC', label: 'LACNIC (South America)' },
+  { value: 'RIPENCC', label: 'RIPENCC (Europe)' },
+];
 
-const WhoisAdapterFieldSet = ({ handleFormEvent, validationState, validationMessage, config}) => (
-  <fieldset>
-    <Input type="select"
-           id="registry"
-           name="registry"
-           label="Registry"
-           autoFocus
-           required
-           onChange={handleFormEvent}
-           help={validationMessage('registry', 'The registry used for the initial lookup, should be the closest to your location.')}
-           bsStyle={validationState('registry')}
-           value={config.registry}
-           labelClassName="col-sm-3"
-           wrapperClassName="col-sm-9">
-      {Object.keys(Registries).map(r => <option value={r}>{Registries[r]}</option>)}
-    </Input>
-  </fieldset>
-);
+const WhoisAdapterFieldSet = React.createClass({
+  propTypes: {
+    config: PropTypes.shape({
+      registry: PropTypes.string.isRequired,
+      connect_timeout: PropTypes.number.isRequired,
+      read_timeout: PropTypes.number.isRequired,
+    }).isRequired,
+    handleFormEvent: PropTypes.func.isRequired,
+    validationMessage: PropTypes.func.isRequired,
+    validationState: PropTypes.func.isRequired,
+  },
 
-WhoisAdapterFieldSet.propTypes = {
-  config: PropTypes.shape({
-    registry: PropTypes.string.isRequired,
-  }).isRequired,
-  handleFormEvent: PropTypes.func.isRequired,
-  validationMessage: PropTypes.func.isRequired,
-  validationState: PropTypes.func.isRequired,
-};
+  handleSelect(fieldName) {
+    return (selectedIndicator) => {
+      const config = lodash.cloneDeep(this.props.config);
+      config[fieldName] = selectedIndicator;
+      this.props.updateConfig(config);
+    };
+  },
+
+  render() {
+    const { config } = this.props;
+
+    return (
+      <fieldset>
+        <Input id="registry"
+               label="Registry"
+               required
+               onChange={this.props.handleFormEvent}
+               help={this.props.validationMessage('registry', 'The registry used for the initial lookup, should be the closest to your location.')}
+               bsStyle={this.props.validationState('registry')}
+               labelClassName="col-sm-3"
+               wrapperClassName="col-sm-9">
+          <Select placeholder="Select registry"
+                  clearable={false}
+                  options={WHOIS_REGISTRIES}
+                  matchProp="value"
+                  onChange={this.handleSelect('registry')}
+                  value={config.registry} />
+        </Input>
+        <Input type="number"
+               id="connect_timeout"
+               name="connect_timeout"
+               label="Connect timeout"
+               required
+               onChange={this.props.handleFormEvent}
+               help={this.props.validationMessage('connect_timeout', 'WHOIS connection timeout in milliseconds.')}
+               bsStyle={this.props.validationState('connect_timeout')}
+               value={config.connect_timeout}
+               labelClassName="col-sm-3"
+               wrapperClassName="col-sm-9" />
+        <Input type="number"
+               id="read_timeout"
+               name="read_timeout"
+               label="Read timeout"
+               required
+               onChange={this.props.handleFormEvent}
+               help={this.props.validationMessage('read_timeout', 'WHOIS connection read timeout in milliseconds.')}
+               bsStyle={this.props.validationState('read_timeout')}
+               value={config.read_timeout}
+               labelClassName="col-sm-3"
+               wrapperClassName="col-sm-9" />
+      </fieldset>
+    );
+  },
+});
 
 export default WhoisAdapterFieldSet;

--- a/src/web/components/adapters/whois/WhoisAdapterSummary.jsx
+++ b/src/web/components/adapters/whois/WhoisAdapterSummary.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 const WhoisAdapterSummary = ({ dataAdapter }) => {
   const { config } = dataAdapter;
@@ -6,7 +7,21 @@ const WhoisAdapterSummary = ({ dataAdapter }) => {
   return (<dl>
     <dt>Registry</dt>
     <dd>{config.registry}</dd>
+    <dt>Connect timeout</dt>
+    <dd>{config.connect_timeout} ms</dd>
+    <dt>Read timeout</dt>
+    <dd>{config.read_timeout} ms</dd>
   </dl>);
+};
+
+WhoisAdapterSummary.propTypes = {
+  dataAdapter: PropTypes.shape({
+    config: PropTypes.shape({
+      registry: PropTypes.string.isRequired,
+      connect_timeout: PropTypes.number.isRequired,
+      read_timeout: PropTypes.number.isRequired,
+    }),
+  }).isRequired,
 };
 
 export default WhoisAdapterSummary;

--- a/src/web/index.jsx
+++ b/src/web/index.jsx
@@ -8,6 +8,7 @@ import { SpamhausEDROPAdapterDocumentation, SpamhausEDROPAdapterFieldSet, Spamha
 import { TorExitNodeAdapterDocumentation, TorExitNodeAdapterFieldSet, TorExitNodeAdapterSummary } from 'components/adapters/torexitnode';
 import { WhoisAdapterDocumentation, WhoisAdapterFieldSet, WhoisAdapterSummary } from 'components/adapters/whois/index';
 import { AbuseChRansomAdapterDocumentation, AbuseChRansomAdapterFieldSet, AbuseChRansomAdapterSummary } from 'components/adapters/abusech/index';
+import { OTXAdapterDocumentation, OTXAdapterFieldSet, OTXAdapterSummary } from './components/adapters/otx';
 
 import packageJson from '../../package.json';
 
@@ -46,6 +47,13 @@ PluginStore.register(new PluginManifest(packageJson, {
       formComponent: AbuseChRansomAdapterFieldSet,
       summaryComponent: AbuseChRansomAdapterSummary,
       documentationComponent: AbuseChRansomAdapterDocumentation,
+    },
+    {
+      type: 'otx-api',
+      displayName: 'Alienvault OTX API',
+      formComponent: OTXAdapterFieldSet,
+      summaryComponent: OTXAdapterSummary,
+      documentationComponent: OTXAdapterDocumentation,
     },
   ],
 }));


### PR DESCRIPTION
This adds a separate OTX data adaper and uses that one for the OTX API lookup tables to fix several issues and actually makes the OTX features work.

It also fixes the Whois data adapter by adding a client with timeouts.

Notes: This needs to be **cherry-picked into 2.4** once merged

---

**ATTENTION:** Run the following MongoDB shell script via `mongo <filename>.js` to cleanup the existing lookup table/cache/adapter entries. This is only needed if you are running with a previous 2.4-alpha/beta.

```js
var db = connect("localhost:27017/graylog");

db.cluster_config.remove({type: "org.graylog.plugins.threatintel.migrations.V20170815111700_CreateThreatIntelLookupTables.MigrationCompleted"})
db.cluster_config.remove({type: "org.graylog.plugins.threatintel.migrations.V20170821100300_MigrateOTXAPIToken.MigrationCompleted"})

db.lut_tables.remove({name: {$in: ["otx-ip", "tor-exit-node-list", "spamhaus-drop", "abuse-ch-ransomware-domains", "whois", "abuse-ch-ransomware-ip"]}})
db.lut_caches.remove({name: {$in: ["spamhaus-e-drop-cache", "otx-ip-cache", "whois-cache", "threat-intel-uncached-adapters"]}})
db.lut_data_adapters.remove({name: {$in: ["otx-ip", "whois", "abuse-ch-ransomware-ip", "tor-exit-node", "spamhaus-drop", "abuse-ch-ransomware-domains"]}})
```