### PR TITLE
Fix "otx_lookup_domain" pipeline function

### DIFF
--- a/src/main/java/org/graylog/plugins/threatintel/functions/otx/AbstractOTXLookupFunction.java
+++ b/src/main/java/org/graylog/plugins/threatintel/functions/otx/AbstractOTXLookupFunction.java
@@ -26,7 +26,7 @@ abstract class AbstractOTXLookupFunction extends LookupTableFunction<OTXLookupRe
     }
 
     protected OTXLookupResult lookupDomain(final String domain) {
-        return lookupIntel(domain, ipLookupFunction);
+        return lookupIntel(domain, domainLookupFunction);
     }
 
     private OTXLookupResult lookupIntel(final String key, final LookupTableService.Function lookupFunction) {


### PR DESCRIPTION
Fixes Graylog2/graylog2-server#4489

Notice: This needs to be **cherry-picked into 2.4** once merged