### PR TITLE
Removing usages of deprecated React.createClass().

### DIFF
--- a/src/web/components/ThreatIntelPluginConfig.jsx
+++ b/src/web/components/ThreatIntelPluginConfig.jsx
@@ -1,12 +1,15 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import { Button } from 'react-bootstrap';
 
 import { BootstrapModalForm, Input } from 'components/bootstrap';
 import { IfPermitted } from 'components/common';
 import ObjectUtils from 'util/ObjectUtils';
 
-const ThreatIntelPluginConfig = React.createClass({
+const ThreatIntelPluginConfig = createReactClass({
+  displayName: 'ThreatIntelPluginConfig',
+
   propTypes: {
     config: PropTypes.object,
     updateConfig: PropTypes.func.isRequired,

--- a/src/web/components/adapters/abusech/AbuseChRansomAdapterDocumentation.jsx
+++ b/src/web/components/adapters/abusech/AbuseChRansomAdapterDocumentation.jsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import { Alert } from 'react-bootstrap';
 
-const AbuseChRansomAdapterDocumentation = React.createClass({
+class AbuseChRansomAdapterDocumentation extends React.Component {
   render() {
     return (<div>
       <p>The <a href="https://ransomwaretracker.abuse.ch/blocklist/" target="_blank">abuse.ch ransomware tracker</a> offers various types of blocklists that allows you to block Ransomware botnet C&C traffic.</p>
@@ -14,7 +14,7 @@ const AbuseChRansomAdapterDocumentation = React.createClass({
       </Alert>
 
     </div>);
-  },
-});
+  }
+}
 
 export default AbuseChRansomAdapterDocumentation;

--- a/src/web/components/adapters/abusech/AbuseChRansomAdapterFieldSet.jsx
+++ b/src/web/components/adapters/abusech/AbuseChRansomAdapterFieldSet.jsx
@@ -5,32 +5,32 @@ import ObjectUtils from 'util/ObjectUtils';
 import { Input } from 'components/bootstrap';
 import { Select, TimeUnitInput } from 'components/common';
 
-const AbuseChRansomAdapterFieldSet = React.createClass({
-  propTypes: {
+class AbuseChRansomAdapterFieldSet extends React.Component {
+  static propTypes = {
     config: PropTypes.object.isRequired,
 // eslint-disable-next-line react/no-unused-prop-types
     updateConfig: PropTypes.func.isRequired,
     handleFormEvent: PropTypes.func.isRequired,
     validationState: PropTypes.func.isRequired,
     validationMessage: PropTypes.func.isRequired,
-  },
+  };
 
-  _update(value, unit, enabled, name) {
+  _update = (value, unit, enabled, name) => {
     const config = ObjectUtils.clone(this.props.config);
     config[name] = enabled ? value : 0;
     config[`${name}_unit`] = unit;
     this.props.updateConfig(config);
-  },
+  };
 
-  updateRefreshInterval(value, unit, enabled) {
+  updateRefreshInterval = (value, unit, enabled) => {
     this._update(value, unit, enabled, 'refresh_interval');
-  },
+  };
 
-  _onBlocklistTypeSelect(id) {
+  _onBlocklistTypeSelect = (id) => {
     const config = ObjectUtils.clone(this.props.config);
     config.blocklist_type = id;
     this.props.updateConfig(config);
-  },
+  };
 
   render() {
     const config = this.props.config;
@@ -63,7 +63,7 @@ const AbuseChRansomAdapterFieldSet = React.createClass({
                      labelClassName="col-sm-3"
                      wrapperClassName="col-sm-9" />
     </fieldset>);
-  },
-});
+  }
+}
 
 export default AbuseChRansomAdapterFieldSet;

--- a/src/web/components/adapters/abusech/AbuseChRansomAdapterSummary.jsx
+++ b/src/web/components/adapters/abusech/AbuseChRansomAdapterSummary.jsx
@@ -2,10 +2,10 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { TimeUnit } from 'components/common';
 
-const AbuseChRansomAdapterSummary = React.createClass({
-  propTypes: {
+class AbuseChRansomAdapterSummary extends React.Component {
+  static propTypes = {
     dataAdapter: PropTypes.object.isRequired,
-  },
+  };
 
   render() {
     const config = this.props.dataAdapter.config;
@@ -20,7 +20,7 @@ const AbuseChRansomAdapterSummary = React.createClass({
       <dt>Update interval</dt>
       <dd><TimeUnit value={config.refresh_interval} unit={config.refresh_interval_unit} /></dd>
     </dl>);
-  },
-});
+  }
+}
 
 export default AbuseChRansomAdapterSummary;

--- a/src/web/components/adapters/otx/OTXAdapterDocumentation.jsx
+++ b/src/web/components/adapters/otx/OTXAdapterDocumentation.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 
 import { ExternalLink } from 'components/common';
 
-const OTXAdapterDocumentation = React.createClass({
+class OTXAdapterDocumentation extends React.Component {
   render() {
     const style = { marginBottom: 10 };
     return (
@@ -70,7 +70,7 @@ const OTXAdapterDocumentation = React.createClass({
         </p>
       </div>
     );
-  },
-});
+  }
+}
 
 export default OTXAdapterDocumentation;

--- a/src/web/components/adapters/otx/OTXAdapterFieldSet.jsx
+++ b/src/web/components/adapters/otx/OTXAdapterFieldSet.jsx
@@ -18,8 +18,8 @@ const OTX_INDICATORS = [
   { label: 'Correlation-Rule', value: 'correlation-rule' },
 ];
 
-const OTXAdapterFieldSet = React.createClass({
-  propTypes: {
+class OTXAdapterFieldSet extends React.Component {
+  static propTypes = {
     config: PropTypes.shape({
       indicator: PropTypes.string.isRequired,
       api_key: PropTypes.string,
@@ -33,15 +33,15 @@ const OTXAdapterFieldSet = React.createClass({
     handleFormEvent: PropTypes.func.isRequired,
     validationState: PropTypes.func.isRequired,
     validationMessage: PropTypes.func.isRequired,
-  },
+  };
 
-  handleSelect(fieldName) {
+  handleSelect = (fieldName) => {
     return (selectedIndicator) => {
       const config = lodash.cloneDeep(this.props.config);
       config[fieldName] = selectedIndicator;
       this.props.updateConfig(config);
     };
-  },
+  };
 
   render() {
     const { config } = this.props;
@@ -129,7 +129,7 @@ const OTXAdapterFieldSet = React.createClass({
                wrapperClassName="col-sm-9" />
       </fieldset>
     );
-  },
-});
+  }
+}
 
 export default OTXAdapterFieldSet;

--- a/src/web/components/adapters/otx/OTXAdapterSummary.jsx
+++ b/src/web/components/adapters/otx/OTXAdapterSummary.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const OTXAdapterSummary = React.createClass({
-  propTypes: {
+class OTXAdapterSummary extends React.Component {
+  static propTypes = {
     dataAdapter: PropTypes.shape({
       config: PropTypes.shape({
         indicator: PropTypes.string.isRequired,
@@ -14,7 +14,7 @@ const OTXAdapterSummary = React.createClass({
         http_read_timeout: PropTypes.number.isRequired,
       }),
     }),
-  },
+  };
 
   render() {
     const { config } = this.props.dataAdapter;
@@ -37,7 +37,7 @@ const OTXAdapterSummary = React.createClass({
         <dd>{config.http_read_timeout} ms</dd>
       </dl>
     );
-  },
-});
+  }
+}
 
 export default OTXAdapterSummary;

--- a/src/web/components/adapters/whois/WhoisAdapterFieldSet.jsx
+++ b/src/web/components/adapters/whois/WhoisAdapterFieldSet.jsx
@@ -3,8 +3,8 @@ import PropTypes from 'prop-types';
 
 import { Input } from 'components/bootstrap';
 
-const WhoisAdapterFieldSet = React.createClass({
-  propTypes: {
+class WhoisAdapterFieldSet extends React.Component {
+  static propTypes = {
     config: PropTypes.shape({
       connect_timeout: PropTypes.number.isRequired,
       read_timeout: PropTypes.number.isRequired,
@@ -12,7 +12,7 @@ const WhoisAdapterFieldSet = React.createClass({
     handleFormEvent: PropTypes.func.isRequired,
     validationMessage: PropTypes.func.isRequired,
     validationState: PropTypes.func.isRequired,
-  },
+  };
 
   render() {
     const { config } = this.props;
@@ -43,7 +43,7 @@ const WhoisAdapterFieldSet = React.createClass({
                wrapperClassName="col-sm-9" />
       </fieldset>
     );
-  },
-});
+  }
+}
 
 export default WhoisAdapterFieldSet;


### PR DESCRIPTION
This PR was generated using the class.js react codemod[1]. It converts all
suitable react components to ES6 classes. If an ES5 component which uses
`React.createClass()` is not suitable for conversion, it uses the
`createReactClass()` helper supplied by the `create-react-class` module.

This change is necessary in preparation for React 16, which removes
`React.createClass()` completely[2]. The codemod used claims to be very
reliable even in corner cases and supposedly `has converted thousands of
components internally at Facebook.`.

[1]: https://github.com/reactjs/react-codemod#explanation-of-the-new-es2015-class-transform-with-property-initializers
[2]: https://reactjs.org/blog/2017/04/07/react-v15.5.0.html#migrating-from-reactcreateclass

It was run like this:

```
$ jscodeshift --extensions js,jsx -t ~/graylog2/react-codemod/transforms/class.js src
Processing 22 files...
Spawning 7 workers...
Sending 4 files to free worker...
Sending 4 files to free worker...
Sending 4 files to free worker...
Sending 4 files to free worker...
Sending 4 files to free worker...
Sending 2 files to free worker...
src/web/components/ThreatIntelPluginConfig.jsx: `ThreatIntelPluginConfig` was skipped because of API calls that will be removed. Remove calls to `getDefaultProps` and/or `getInitialState` in your React component and re-run this script.
All done.
Results:
0 errors
14 unmodified
0 skipped
8 ok
Time elapsed: 1.989seconds
```