### PR TITLE
Fix otx threat names ids not populating

### DIFF
--- a/src/main/java/org/graylog/plugins/threatintel/functions/otx/AbstractOTXLookupFunction.java
+++ b/src/main/java/org/graylog/plugins/threatintel/functions/otx/AbstractOTXLookupFunction.java
@@ -6,6 +6,8 @@ import org.graylog.plugins.threatintel.functions.misc.LookupTableFunction;
 import org.graylog2.lookup.LookupTableService;
 import org.graylog2.plugin.lookup.LookupResult;
 
+import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -39,9 +41,10 @@ abstract class AbstractOTXLookupFunction extends LookupTableFunction<OTXLookupRe
 
             if (pulseCount > 0) {
                 result.put("otx_threat_indicated", true);
-                if (lookupResult.multiValue() != null && lookupResult.multiValue() instanceof List) {
+                if (lookupResult.multiValue() != null && lookupResult.multiValue() instanceof LinkedHashMap) {
                     Joiner joiner = Joiner.on(", ").skipNulls();
-                    final List<Map<String, Object>> pulses = (List<Map<String, Object>>)lookupResult.multiValue();
+                    final LinkedHashMap<String, Object> pulse_info = (LinkedHashMap<String, Object>)lookupResult.multiValue().get("pulse_info");
+                    final List<Map<String, Object>> pulses = (List<Map<String, Object>>)pulse_info.get("pulses");
 
                     final List<String> ids = pulses.stream()
                             .map(pulse -> String.valueOf(pulse.get("id")))

--- a/src/main/java/org/graylog/plugins/threatintel/functions/otx/AbstractOTXLookupFunction.java
+++ b/src/main/java/org/graylog/plugins/threatintel/functions/otx/AbstractOTXLookupFunction.java
@@ -6,7 +6,6 @@ import org.graylog.plugins.threatintel.functions.misc.LookupTableFunction;
 import org.graylog2.lookup.LookupTableService;
 import org.graylog2.plugin.lookup.LookupResult;
 
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;

--- a/src/main/java/org/graylog/plugins/threatintel/functions/otx/AbstractOTXLookupFunction.java
+++ b/src/main/java/org/graylog/plugins/threatintel/functions/otx/AbstractOTXLookupFunction.java
@@ -40,9 +40,9 @@ abstract class AbstractOTXLookupFunction extends LookupTableFunction<OTXLookupRe
 
             if (pulseCount > 0) {
                 result.put("otx_threat_indicated", true);
-                if (lookupResult.multiValue() != null && lookupResult.multiValue() instanceof LinkedHashMap) {
+                if (lookupResult.multiValue() != null && lookupResult.multiValue() instanceof Map) {
                     Joiner joiner = Joiner.on(", ").skipNulls();
-                    final LinkedHashMap<String, Object> pulse_info = (LinkedHashMap<String, Object>)lookupResult.multiValue().get("pulse_info");
+                    final Map<String, Object> pulse_info = (Map<String, Object>)lookupResult.multiValue().get("pulse_info");
                     final List<Map<String, Object>> pulses = (List<Map<String, Object>>)pulse_info.get("pulses");
 
                     final List<String> ids = pulses.stream()


### PR DESCRIPTION
When using the `otx_lookup_ip` and `otx_lookup_domain` in a pipeline rule. All that was being passed back was `otx_threat_indicated`. If a threat was indicated `otx_threat_ids` and `otx_threat_names` are currently not being returned. Just `otx_threat_indicated: true`. This PR fixes that.