### PR TITLE
Add config for no-response bot

### DIFF
--- a/.github/no-response.yml
+++ b/.github/no-response.yml
@@ -1,0 +1,2 @@
+daysUntilClose: 30
+responseRequiredLabel: needs-input


### PR DESCRIPTION
Add config needed for no-response bot to automatically close issues that needs-input label has been on for more than 30 days (without a response from issue author).