### PR TITLE
Fix bug that always causes a false Tor Exit Node response

### DIFF
--- a/src/main/java/org/graylog/plugins/threatintel/functions/tor/TorExitNodeLookupFunction.java
+++ b/src/main/java/org/graylog/plugins/threatintel/functions/tor/TorExitNodeLookupFunction.java
@@ -43,9 +43,9 @@ public class TorExitNodeLookupFunction extends LookupTableFunction<GenericLookup
 
         final LookupResult lookupResult = this.lookupFunction.lookup(ip.trim());
         if (lookupResult != null && !lookupResult.isEmpty()) {
-            final Object value = lookupResult.singleValue();
 
             // If not a String, then fall through to false at the end of the method.
+            final Object value = lookupResult.singleValue();
             if (value instanceof String) {
                 return Strings.isNotBlank((String) value) ? GenericLookupResult.TRUE : GenericLookupResult.FALSE;
             }

--- a/src/main/java/org/graylog/plugins/threatintel/functions/tor/TorExitNodeLookupFunction.java
+++ b/src/main/java/org/graylog/plugins/threatintel/functions/tor/TorExitNodeLookupFunction.java
@@ -1,5 +1,6 @@
 package org.graylog.plugins.threatintel.functions.tor;
 
+import org.apache.logging.log4j.util.Strings;
 import org.graylog.plugins.pipelineprocessor.EvaluationContext;
 import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionArgs;
 import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionDescriptor;
@@ -43,11 +44,10 @@ public class TorExitNodeLookupFunction extends LookupTableFunction<GenericLookup
         final LookupResult lookupResult = this.lookupFunction.lookup(ip.trim());
         if (lookupResult != null && !lookupResult.isEmpty()) {
             final Object value = lookupResult.singleValue();
-            if (value instanceof Boolean) {
-                return (Boolean) value ? GenericLookupResult.TRUE : GenericLookupResult.FALSE;
-            }
+
+            // If not a String, then fall through to false at the end of the method.
             if (value instanceof String) {
-                return Boolean.valueOf((String) value) ? GenericLookupResult.TRUE : GenericLookupResult.FALSE;
+                return Strings.isNotBlank((String) value) ? GenericLookupResult.TRUE : GenericLookupResult.FALSE;
             }
         }
 

--- a/src/main/java/org/graylog/plugins/threatintel/functions/tor/TorExitNodeLookupFunction.java
+++ b/src/main/java/org/graylog/plugins/threatintel/functions/tor/TorExitNodeLookupFunction.java
@@ -1,6 +1,6 @@
 package org.graylog.plugins.threatintel.functions.tor;
 
-import org.apache.logging.log4j.util.Strings;
+import com.google.common.base.Strings;
 import org.graylog.plugins.pipelineprocessor.EvaluationContext;
 import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionArgs;
 import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionDescriptor;
@@ -47,7 +47,7 @@ public class TorExitNodeLookupFunction extends LookupTableFunction<GenericLookup
             // If not a String, then fall through to false at the end of the method.
             final Object value = lookupResult.singleValue();
             if (value instanceof String) {
-                return Strings.isNotBlank((String) value) ? GenericLookupResult.TRUE : GenericLookupResult.FALSE;
+                return !Strings.isNullOrEmpty((String) value) ? GenericLookupResult.TRUE : GenericLookupResult.FALSE;
             }
         }
 


### PR DESCRIPTION
Fixes #115 (`tor_lookup` pipeline function always returns a false `threat_indicated` response).

The was previously attempting to parse a boolean response from the Tor Exit Node data adaptor/lookup table (but the table returns the Tor node ID if found). Now, the code correctly return false for a blank/null Tor node ID, and true when an ID of any length is returned.