### PR TITLE
Fix typo in spamhaus content pack to unbreak data adapter installation

### DIFF
--- a/src/main/resources/org/graylog/plugins/threatintel/migrations/V20180906112716_RecreateThreatintelLookupTables-content_pack-spamhaus.json
+++ b/src/main/resources/org/graylog/plugins/threatintel/migrations/V20180906112716_RecreateThreatintelLookupTables-content_pack-spamhaus.json
@@ -8,7 +8,7 @@
                         "@type": "long",
                         "@value": 43200
                     },
-                    "@type": {
+                    "type": {
                         "@type": "string",
                         "@value": "spamhaus-edrop"
                     }


### PR DESCRIPTION
Fixes Graylog2/graylog2-server#5636

(cherry picked from commit 5945177f9277303a067ac142b07e66fb84c8788a)