### PR TITLE
Fix auto-completion in several drop-down fields

### DIFF
--- a/src/web/components/adapters/abusech/AbuseChRansomAdapterFieldSet.jsx
+++ b/src/web/components/adapters/abusech/AbuseChRansomAdapterFieldSet.jsx
@@ -52,7 +52,7 @@ class AbuseChRansomAdapterFieldSet extends React.Component {
         <Select placeholder="Select the type of blocklist"
                 clearable={false}
                 options={blocklistTypes}
-                matchProp="value"
+                matchProp="label"
                 onChange={this._onBlocklistTypeSelect}
                 value={config.blocklist_type} />
       </Input>

--- a/src/web/components/adapters/otx/OTXAdapterFieldSet.jsx
+++ b/src/web/components/adapters/otx/OTXAdapterFieldSet.jsx
@@ -59,7 +59,7 @@ class OTXAdapterFieldSet extends React.Component {
           <Select placeholder="Select indicator"
                   clearable={false}
                   options={OTX_INDICATORS}
-                  matchProp="value"
+                  matchProp="label"
                   onChange={this.handleSelect('indicator')}
                   value={config.indicator} />
         </Input>


### PR DESCRIPTION
In all these cases the matchProp needs to be set to "label" and not "value"
because the value contains the object ID or another identifier.

After this, the auto-completion is looking at same data that the user
is seeing.

Refs Graylog2/graylog2-server#5659