### PR TITLE
Adding Dependabot configuration to repository.

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,11 @@
+version: 1
+
+update_configs:
+  - package_manager: "javascript"
+    directory: "/"
+    update_schedule: "live"
+
+  - package_manager: "java:maven"
+    directory: "/"
+    update_schedule: "daily"
+


### PR DESCRIPTION
Instead of configuring Dependabot using its web interface, this PR adds a [configuration file](https://dependabot.com/docs/config-file/) for it to git. What it is configuring is:

  * Java dependency updates (daily)
  * JavaScript dependency updates (live)

No automerging is configured, PR labels default to `dependencies` (no `ready-for-review`, as it seems to become redundant due to draft PRs).