### PR TITLE
Updating yarn lockfile after changes.

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2105,6 +2105,7 @@ eslint-config-airbnb@17.1.1:
     eslint "5.16.0"
     eslint-config-airbnb "17.1.1"
     eslint-import-resolver-webpack "0.11.1"
+    eslint-plugin-flowtype "^4.5.2"
     eslint-plugin-import "2.18.2"
     eslint-plugin-jsx-a11y "6.2.3"
     eslint-plugin-react "7.16.0"
@@ -2141,6 +2142,13 @@ eslint-module-utils@^2.4.0:
   dependencies:
     debug "^2.6.8"
     pkg-dir "^2.0.0"
+
+eslint-plugin-flowtype@^4.5.2:
+  version "4.5.3"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-flowtype/-/eslint-plugin-flowtype-4.5.3.tgz#21322e62c206cb4440d32ed3ba8eabe14e6d0fdf"
+  integrity sha512-9PBGkk3dQ2TnP04Zrm8ziVHyNIYzd24PEY12I5DXC/R35+3if0C1/PqTQW94v3okKWoBh2/7EysMEX9AimONjQ==
+  dependencies:
+    lodash "^4.17.15"
 
 eslint-plugin-import@2.18.2:
   version "2.18.2"
@@ -2693,11 +2701,11 @@ graceful-fs@^4.1.15:
   integrity sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==
 
 "graylog-web-plugin@file:../graylog2-server/graylog2-web-interface/packages/graylog-web-plugin":
-  version "3.2.0-SNAPSHOT"
+  version "3.2.0-beta.2-SNAPSHOT"
   dependencies:
     "@babel/preset-env" "7.6.3"
     babel-eslint "9.0.0"
-    eslint-config-graylog "file:../../.cache/yarn/v4/npm-graylog-web-plugin-3.2.0-SNAPSHOT-bf9ec4ce-d021-4fcd-bd1b-3cc08c62d0e0-1572950652167/node_modules/eslint-config-graylog"
+    eslint-config-graylog "file:../../../Library/Caches/Yarn/v4/npm-graylog-web-plugin-3.2.0-beta.2-SNAPSHOT-6ca87dcf-60c8-4b60-a754-aa7707f282f1-1578321959143/node_modules/eslint-config-graylog"
     html-webpack-plugin "3.2.0"
     javascript-natural-sort "0.7.1"
     jquery "3.4.1"
@@ -2711,8 +2719,8 @@ graceful-fs@^4.1.15:
     react-router "3.2.1"
     react-router-bootstrap "0.23.2"
     reflux "0.2.13"
-    styled-components "^4.3.2"
-    styled-theming "^2.2.0"
+    styled-components "4.3.2"
+    styled-theming "2.2.0"
     webpack "4.41.2"
     webpack-cleanup-plugin "0.5.1"
     webpack-cli "3.3.7"
@@ -5108,10 +5116,10 @@ strip-json-comments@^2.0.1, strip-json-comments@~2.0.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
 
-styled-components@^4.3.2:
-  version "4.4.1"
-  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-4.4.1.tgz#e0631e889f01db67df4de576fedaca463f05c2f2"
-  integrity sha512-RNqj14kYzw++6Sr38n7197xG33ipEOktGElty4I70IKzQF1jzaD1U4xQ+Ny/i03UUhHlC5NWEO+d8olRCDji6g==
+styled-components@4.3.2:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-4.3.2.tgz#4ca81918c812d3006f60ac5fdec7d6b64a9509cc"
+  integrity sha512-NppHzIFavZ3TsIU3R1omtddJ0Bv1+j50AKh3ZWyXHuFvJq1I8qkQ5mZ7uQgD89Y8zJNx2qRo6RqAH1BmoVafHw==
   dependencies:
     "@babel/helper-module-imports" "^7.0.0"
     "@babel/traverse" "^7.0.0"
@@ -5127,7 +5135,7 @@ styled-components@^4.3.2:
     stylis-rule-sheet "^0.0.10"
     supports-color "^5.5.0"
 
-styled-theming@^2.2.0:
+styled-theming@2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/styled-theming/-/styled-theming-2.2.0.tgz#3084e43d40eaab4bc11ebafd3de04e3622fee37e"
   integrity sha1-MITkPUDqq0vBHrr9PeBONiL+434=


### PR DESCRIPTION
Due to changes in Graylog2/graylog2-server#6859 affecting a module shared by all plugins, these changes to the yarn lockfile became necessary.