### PR TITLE
Support IPv6 in in_private_net function, reduce noise on errors

### DIFF
--- a/src/main/java/org/graylog/plugins/threatintel/functions/misc/PrivateNetLookupFunction.java
+++ b/src/main/java/org/graylog/plugins/threatintel/functions/misc/PrivateNetLookupFunction.java
@@ -24,6 +24,7 @@ import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionArgs;
 import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionDescriptor;
 import org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor;
 import org.graylog.plugins.threatintel.tools.PrivateNet;
+import org.graylog2.shared.utilities.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -64,7 +65,7 @@ public class PrivateNetLookupFunction extends AbstractFunction<Boolean> {
 
             return result;
         } catch (Exception e) {
-            LOG.error("Could not run private net lookup for IP [{}].", ip, e);
+            LOG.error("Could not run private net lookup for IP [{}]: {}", ip, ExceptionUtils.getRootCauseMessage(e));
             return null;
         }
     }

--- a/src/main/java/org/graylog/plugins/threatintel/functions/misc/PrivateNetLookupFunction.java
+++ b/src/main/java/org/graylog/plugins/threatintel/functions/misc/PrivateNetLookupFunction.java
@@ -39,7 +39,7 @@ public class PrivateNetLookupFunction extends AbstractFunction<Boolean> {
     public static final String NAME = "in_private_net";
     private static final String VALUE = "ip_address";
 
-    private final ParameterDescriptor<String, String> valueParam = ParameterDescriptor.string(VALUE).description("The IPv4 address to look up.").build();
+    private final ParameterDescriptor<String, String> valueParam = ParameterDescriptor.string(VALUE).description("The IP address to look up.").build();
 
     protected Timer lookupTime;
 
@@ -75,7 +75,7 @@ public class PrivateNetLookupFunction extends AbstractFunction<Boolean> {
     public FunctionDescriptor<Boolean> descriptor() {
         return FunctionDescriptor.<Boolean>builder()
                 .name(NAME)
-                .description("Check if an IPv4 address is in a private network as defined in RFC 1918. (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16)")
+                .description("Check if an IP address is in a private network as defined in RFC 1918 (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16) or RFC 4193 (fc00::/7)")
                 .params(valueParam)
                 .returnType(Boolean.class)
                 .build();

--- a/src/main/java/org/graylog/plugins/threatintel/tools/PrivateNet.java
+++ b/src/main/java/org/graylog/plugins/threatintel/tools/PrivateNet.java
@@ -17,26 +17,25 @@
 package org.graylog.plugins.threatintel.tools;
 
 import com.google.common.net.InetAddresses;
-import org.apache.commons.net.util.SubnetUtils;
+
+import java.net.Inet6Address;
+import java.net.InetAddress;
 
 public class PrivateNet {
 
-    public static final SubnetUtils.SubnetInfo TEN = new SubnetUtils("10.0.0.0/8").getInfo();
-    public static final SubnetUtils.SubnetInfo ONE_HUNDRED_SEVENTY_TWO = new SubnetUtils("172.16.0.0/12").getInfo();
-    public static final SubnetUtils.SubnetInfo ONE_HUNDRED_NINETY_TWO = new SubnetUtils("192.168.0.0/16").getInfo();
-
-    /**
-     * Checks if an IPv4 address is part of a private network as defined in RFC 1918.
+   /**
+     * Checks if an IPv4 address is part of a private network as defined in RFC 1918. This ignores IPv6 addresses for now and always returns false for them.
      *
      * @param ip The IPv4 address to check
      * @return
      */
     public static boolean isInPrivateAddressSpace(String ip) {
-        if(!InetAddresses.isInetAddress(ip)) {
+        InetAddress inetAddress = InetAddresses.forString(ip);
+        if (inetAddress instanceof Inet6Address) {
+            // we don't deal with IPv6 unique local addresses currently.
             return false;
         }
-
-        return ONE_HUNDRED_SEVENTY_TWO.isInRange(ip) || TEN.isInRange(ip) || ONE_HUNDRED_NINETY_TWO.isInRange(ip);
+        return inetAddress.isSiteLocalAddress();
     }
 
 }

--- a/src/main/java/org/graylog/plugins/threatintel/tools/PrivateNet.java
+++ b/src/main/java/org/graylog/plugins/threatintel/tools/PrivateNet.java
@@ -17,19 +17,20 @@
 package org.graylog.plugins.threatintel.tools;
 
 import com.google.common.net.InetAddresses;
-import org.jboss.netty.handler.ipfilter.CIDR;
+import org.graylog2.utilities.IpSubnet;
 
 import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 
+@SuppressWarnings("UnstableApiUsage")
 public class PrivateNet {
 
-    private static CIDR UNIQUE_LOCAL_ADDR_MASK = null;
+    private static IpSubnet UNIQUE_LOCAL_ADDR_MASK = null;
     static {
         try {
             // RFC 4193: https://tools.ietf.org/html/rfc4193#section-3.1
-            UNIQUE_LOCAL_ADDR_MASK = CIDR.newCIDR("FC00::/7");
+            UNIQUE_LOCAL_ADDR_MASK = new IpSubnet("FC00::/7");
         } catch (UnknownHostException ignored) {
         }
 
@@ -39,7 +40,7 @@ public class PrivateNet {
     *
      *
      * @param ip The IP address to check
-     * @return
+     * @return true if IP address is in a private subnet, false if not or unknown
      */
     public static boolean isInPrivateAddressSpace(String ip) {
         InetAddress inetAddress = InetAddresses.forString(ip);

--- a/src/test/java/org/graylog/plugins/threatintel/tools/PrivateNetTest.java
+++ b/src/test/java/org/graylog/plugins/threatintel/tools/PrivateNetTest.java
@@ -28,6 +28,8 @@ public class PrivateNetTest {
         assertTrue(PrivateNet.isInPrivateAddressSpace("172.16.20.50"));
         assertTrue(PrivateNet.isInPrivateAddressSpace("192.168.1.1"));
         assertFalse(PrivateNet.isInPrivateAddressSpace("99.42.44.219"));
+        assertFalse(PrivateNet.isInPrivateAddressSpace("ff02:0:0:0:0:0:0:fb"));
+        assertThrows(IllegalArgumentException.class, () -> PrivateNet.isInPrivateAddressSpace("this is not an IP address"));
     }
 
 }

--- a/src/test/java/org/graylog/plugins/threatintel/tools/PrivateNetTest.java
+++ b/src/test/java/org/graylog/plugins/threatintel/tools/PrivateNetTest.java
@@ -29,6 +29,7 @@ public class PrivateNetTest {
         assertTrue(PrivateNet.isInPrivateAddressSpace("192.168.1.1"));
         assertFalse(PrivateNet.isInPrivateAddressSpace("99.42.44.219"));
         assertFalse(PrivateNet.isInPrivateAddressSpace("ff02:0:0:0:0:0:0:fb"));
+        assertTrue(PrivateNet.isInPrivateAddressSpace("fd80:0:0:0:0:0:0:fb"));
         assertThrows(IllegalArgumentException.class, () -> PrivateNet.isInPrivateAddressSpace("this is not an IP address"));
     }
 


### PR DESCRIPTION
The `in_private_net` function now supports unique local addresses in IPv6 (entire `FC00::/7` subnet)

When something else than an IP address is passed in, the function is now less chatty and does not log the stacktrace anymore. For IP addresses it should never log anything.

fixes #156
fixes Graylog2/graylog2-server#4624
related to #33