### PR TITLE
Use ESLint settings configured in eslint-config-graylog

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   },
   "scripts": {
     "build": "webpack",
-    "lint": "eslint src"
+    "lint": "eslint src",
+    "lint:path": "eslint"
   },
   "eslintConfig": {
     "extends": "graylog"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "build": "webpack",
-    "lint": "eslint --ext js,jsx src"
+    "lint": "eslint src"
   },
   "eslintConfig": {
     "extends": "graylog"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,11 @@
     "url": "https://github.com/Graylog2/graylog-plugin-threatintel"
   },
   "scripts": {
-    "build": "webpack"
+    "build": "webpack",
+    "lint": "eslint --ext js,jsx src"
+  },
+  "eslintConfig": {
+    "extends": "graylog"
   },
   "keywords": [
     "graylog"


### PR DESCRIPTION
## Description
This PR unifies the ESLint configuration by extending `eslint-config-graylog` in the `eslintConfig` of the `package.json`.

With Graylog2/graylog2-server#9309 all required settings are now part of `eslint-config-graylog`.
This is also necessary to enable the built-in ESLint editor support.

