### PR TITLE
Backport updates to WHOIS data adapter

### DIFF
--- a/src/main/java/org/graylog/plugins/threatintel/whois/ip/InternetRegistry.java
+++ b/src/main/java/org/graylog/plugins/threatintel/whois/ip/InternetRegistry.java
@@ -33,5 +33,4 @@ public enum InternetRegistry {
     public String getWhoisServer() {
         return whoisServer;
     }
-
 }

--- a/src/main/java/org/graylog/plugins/threatintel/whois/ip/WhoisIpLookup.java
+++ b/src/main/java/org/graylog/plugins/threatintel/whois/ip/WhoisIpLookup.java
@@ -83,11 +83,12 @@ public class WhoisIpLookup {
             whoisClient.setDefaultPort(PORT);
             whoisClient.setConnectTimeout(connectTimeout);
             whoisClient.setDefaultTimeout(readTimeout);
+            String query = parser.buildQueryForIp(ip);
 
             try (final Timer.Context ignored = whoisRequestTimer.time()) {
                 whoisClient.connect(registry.getWhoisServer());
 
-                IOUtils.readLines(whoisClient.getInputStream(ip), StandardCharsets.UTF_8).forEach(parser::readLine);
+                IOUtils.readLines(whoisClient.getInputStream(query), StandardCharsets.UTF_8).forEach(parser::readLine);
             }
 
             // When we encounter a registry redirect we recursively call this method with the new registry server.

--- a/src/main/java/org/graylog/plugins/threatintel/whois/ip/parsers/ARINResponseParser.java
+++ b/src/main/java/org/graylog/plugins/threatintel/whois/ip/parsers/ARINResponseParser.java
@@ -18,13 +18,27 @@ package org.graylog.plugins.threatintel.whois.ip.parsers;
 
 public class ARINResponseParser extends WhoisParser {
 
+    private NetworkType prevNetworkType = null;
+    private NetworkType currNetworkType = null;
+
     @Override
     public void readLine(String line) {
         if (line.startsWith("#") || line.isEmpty()) {
             return;
         }
 
-        if(line.startsWith("Organization:") && this.organization == null) {
+        // In some cases, ARIN may have multiple results with different NetType values.  When that happens,
+        //  we want to use the data from the entry with the data closest to the customer actually using the IP.
+        if (line.startsWith("NetType:")) {
+            prevNetworkType = currNetworkType;
+            currNetworkType = NetworkType.getEnum(lineValue(line));
+            if (null != currNetworkType && currNetworkType.isMoreSpecificThan(prevNetworkType)) {
+                this.organization = null;
+                this.countryCode = null;
+            }
+        }
+
+        if((line.startsWith("Organization:") || line.startsWith("Customer:")) && this.organization == null) {
             this.organization = lineValue(line);
         }
 
@@ -38,4 +52,41 @@ public class ARINResponseParser extends WhoisParser {
         }
     }
 
+    @Override
+    public String buildQueryForIp(String ip) {
+        // This query ensures that we get all of the records when there are multiple results rather than just a list of
+        //  record summaries without details.
+        return "n + " + ip;
+    }
+
+    private enum NetworkType {
+        // Network types are defined in ARIN's documentation: https://www.arin.net/resources/registry/whois/#network
+        // Arranged in order of decreasing preference.  Do not reorder unless preference order changes
+        REASSIGNED("Reassigned"),
+        DIRECT_ASSIGNMENT("Direct Assignment"),
+        REALLOCATED("Reallocated"),
+        DIRECT_ALLOCATION("Direct Allocation");
+
+        private String displayName;
+
+        NetworkType(String displayName) { this.displayName = displayName; }
+
+        String displayName() { return displayName; }
+
+        boolean isMoreSpecificThan(NetworkType netType) {
+            if (null == netType) {
+                return true;
+            }
+            return (this.ordinal() < netType.ordinal());
+        }
+
+        static NetworkType getEnum(String value) {
+            for (NetworkType v : values()) {
+                if (value.equalsIgnoreCase(v.displayName())) {
+                    return v;
+                }
+            }
+            return null;
+        }
+    }
 }

--- a/src/main/java/org/graylog/plugins/threatintel/whois/ip/parsers/WhoisParser.java
+++ b/src/main/java/org/graylog/plugins/threatintel/whois/ip/parsers/WhoisParser.java
@@ -50,6 +50,8 @@ public abstract class WhoisParser {
         return null;
     }
 
+    public String buildQueryForIp(String ip) { return ip; }
+
     public boolean isRedirect() {
         return isRedirect;
     }

--- a/src/test/java/org/graylog/plugins/threatintel/whois/ip/parsers/ARINResponseParserTest.java
+++ b/src/test/java/org/graylog/plugins/threatintel/whois/ip/parsers/ARINResponseParserTest.java
@@ -203,6 +203,190 @@ public class ARINResponseParserTest {
             "# https://www.arin.net/public/whoisinaccuracy/index.xhtml\n" +
             "#\n";
 
+    private static String TWO_MATCH = "#\n" +
+            "# ARIN WHOIS data and services are subject to the Terms of Use\n" +
+            "# available at: https://www.arin.net/resources/registry/whois/tou/\n" +
+            "#\n" +
+            "# If you see inaccuracies in the results, please report at\n" +
+            "# https://www.arin.net/resources/registry/whois/inaccuracy_reporting/\n" +
+            "#\n" +
+            "# Copyright 1997-2020, American Registry for Internet Numbers, Ltd.\n" +
+            "#\n" +
+            "\n" +
+            "\n" +
+            "\n" +
+            "# start\n" +
+            "\n" +
+            "NetRange:       24.248.0.0 - 24.255.255.255\n" +
+            "CIDR:           24.248.0.0/13\n" +
+            "NetName:        NETBLK-COX-ATLANTA-8\n" +
+            "NetHandle:      NET-24-248-0-0-1\n" +
+            "Parent:         NET24 (NET-24-0-0-0-0)\n" +
+            "NetType:        Direct Allocation\n" +
+            "OriginAS:\n" +
+            "Organization:   Cox Communications Inc. (CXA)\n" +
+            "RegDate:        2003-10-28\n" +
+            "Updated:        2012-03-02\n" +
+            "Comment:        For legal requests/assistance please use the following contact information:\n" +
+            "Comment:\n" +
+            "Comment:        Cox Subpoena Phone: 404-269-0100\n" +
+            "Comment:\n" +
+            "Comment:        Cox Subpoena Info: http://www.cox.com/policy/leainformation/default.asp\n" +
+            "Ref:            https://rdap.arin.net/registry/ip/24.248.0.0\n" +
+            "\n" +
+            "\n" +
+            "\n" +
+            "OrgName:        Cox Communications Inc.\n" +
+            "OrgId:          CXA\n" +
+            "Address:        1400 Lake Hearn Dr.\n" +
+            "City:           Atlanta\n" +
+            "StateProv:      GA\n" +
+            "PostalCode:     30319\n" +
+            "Country:        FOO\n" +
+            "RegDate:\n" +
+            "Updated:        2019-05-24\n" +
+            "Comment:        For legal requests/assistance please use the\n" +
+            "Comment:        following contact information:\n" +
+            "Comment:        Cox Subpoena Info: https://www.cox.com/aboutus/policies/law-enforcement-and-subpoenas-information.html\n" +
+            "Ref:            https://rdap.arin.net/registry/entity/CXA\n" +
+            "\n" +
+            "\n" +
+            "OrgTechHandle: GOODW243-ARIN\n" +
+            "OrgTechName:   Goodwin, Mark\n" +
+            "OrgTechPhone:  +1-404-269-4416\n" +
+            "OrgTechEmail:  mark.goodwin@cox.com\n" +
+            "OrgTechRef:    https://rdap.arin.net/registry/entity/GOODW243-ARIN\n" +
+            "\n" +
+            "OrgTechHandle: ADA131-ARIN\n" +
+            "OrgTechName:   Anderson, Alvin Demond\n" +
+            "OrgTechPhone:  +1-404-269-4416\n" +
+            "OrgTechEmail:  alvin.anderson@cox.com\n" +
+            "OrgTechRef:    https://rdap.arin.net/registry/entity/ADA131-ARIN\n" +
+            "\n" +
+            "OrgTechHandle: MEROL3-ARIN\n" +
+            "OrgTechName:   Merola, Cari\n" +
+            "OrgTechPhone:  +1-404-269-4416\n" +
+            "OrgTechEmail:  cari.merola@cox.com\n" +
+            "OrgTechRef:    https://rdap.arin.net/registry/entity/MEROL3-ARIN\n" +
+            "\n" +
+            "OrgAbuseHandle: IC146-ARIN\n" +
+            "OrgAbuseName:   Cox Communications Inc\n" +
+            "OrgAbusePhone:  +1-404-269-7626\n" +
+            "OrgAbuseEmail:  abuse@cox.net\n" +
+            "OrgAbuseRef:    https://rdap.arin.net/registry/entity/IC146-ARIN\n" +
+            "\n" +
+            "OrgTechHandle: IPADM754-ARIN\n" +
+            "OrgTechName:   IP Adminstrator\n" +
+            "OrgTechPhone:  +1-404-269-0188\n" +
+            "OrgTechEmail:  sophea.long@cox.com\n" +
+            "OrgTechRef:    https://rdap.arin.net/registry/entity/IPADM754-ARIN\n" +
+            "\n" +
+            "OrgTechHandle: BERUB3-ARIN\n" +
+            "OrgTechName:   Berube, Tori\n" +
+            "OrgTechPhone:  +1-404-269-4416\n" +
+            "OrgTechEmail:  tori.berube@cox.com\n" +
+            "OrgTechRef:    https://rdap.arin.net/registry/entity/BERUB3-ARIN\n" +
+            "\n" +
+            "# end\n" +
+            "\n" +
+            "\n" +
+            "# start\n" +
+            "\n" +
+            "NetRange:       24.255.128.0 - 24.255.255.255\n" +
+            "CIDR:           24.255.128.0/17\n" +
+            "NetName:        NETBLK-WI-RDC-24-255-128-0\n" +
+            "NetHandle:      NET-24-255-128-0-1\n" +
+            "Parent:         NETBLK-COX-ATLANTA-8 (NET-24-248-0-0-1)\n" +
+            "NetType:        Reassigned\n" +
+            "OriginAS:\n" +
+            "Customer:       Cox Communications (C00898431)\n" +
+            "RegDate:        2004-08-31\n" +
+            "Updated:        2004-08-31\n" +
+            "Ref:            https://rdap.arin.net/registry/ip/24.255.128.0\n" +
+            "\n" +
+            "\n" +
+            "CustName:       Cox Communications\n" +
+            "Address:        1400 Lake Hearn Dr.\n" +
+            "City:           Atlanta\n" +
+            "StateProv:      GA\n" +
+            "PostalCode:     30319\n" +
+            "Country:        US\n" +
+            "RegDate:        2004-08-31\n" +
+            "Updated:        2011-03-19\n" +
+            "Ref:            https://rdap.arin.net/registry/entity/C00898431\n" +
+            "\n" +
+            "OrgTechHandle: GOODW243-ARIN\n" +
+            "OrgTechName:   Goodwin, Mark\n" +
+            "OrgTechPhone:  +1-404-269-4416\n" +
+            "OrgTechEmail:  mark.goodwin@cox.com\n" +
+            "OrgTechRef:    https://rdap.arin.net/registry/entity/GOODW243-ARIN\n" +
+            "\n" +
+            "OrgTechHandle: ADA131-ARIN\n" +
+            "OrgTechName:   Anderson, Alvin Demond\n" +
+            "OrgTechPhone:  +1-404-269-4416\n" +
+            "OrgTechEmail:  alvin.anderson@cox.com\n" +
+            "OrgTechRef:    https://rdap.arin.net/registry/entity/ADA131-ARIN\n" +
+            "\n" +
+            "OrgTechHandle: MEROL3-ARIN\n" +
+            "OrgTechName:   Merola, Cari\n" +
+            "OrgTechPhone:  +1-404-269-4416\n" +
+            "OrgTechEmail:  cari.merola@cox.com\n" +
+            "OrgTechRef:    https://rdap.arin.net/registry/entity/MEROL3-ARIN\n" +
+            "\n" +
+            "OrgAbuseHandle: IC146-ARIN\n" +
+            "OrgAbuseName:   Cox Communications Inc\n" +
+            "OrgAbusePhone:  +1-404-269-7626\n" +
+            "OrgAbuseEmail:  abuse@cox.net\n" +
+            "OrgAbuseRef:    https://rdap.arin.net/registry/entity/IC146-ARIN\n" +
+            "\n" +
+            "OrgTechHandle: IPADM754-ARIN\n" +
+            "OrgTechName:   IP Adminstrator\n" +
+            "OrgTechPhone:  +1-404-269-0188\n" +
+            "OrgTechEmail:  sophea.long@cox.com\n" +
+            "OrgTechRef:    https://rdap.arin.net/registry/entity/IPADM754-ARIN\n" +
+            "\n" +
+            "OrgTechHandle: BERUB3-ARIN\n" +
+            "OrgTechName:   Berube, Tori\n" +
+            "OrgTechPhone:  +1-404-269-4416\n" +
+            "OrgTechEmail:  tori.berube@cox.com\n" +
+            "OrgTechRef:    https://rdap.arin.net/registry/entity/BERUB3-ARIN\n" +
+            "\n" +
+            "# end\n" +
+            "\n" +
+            "\n" +
+            "\n" +
+            "#\n" +
+            "# ARIN WHOIS data and services are subject to the Terms of Use\n" +
+            "# available at: https://www.arin.net/resources/registry/whois/tou/\n" +
+            "#\n" +
+            "# If you see inaccuracies in the results, please report at\n" +
+            "# https://www.arin.net/resources/registry/whois/inaccuracy_reporting/\n" +
+            "#\n" +
+            "# Copyright 1997-2020, American Registry for Internet Numbers, Ltd.\n" +
+            "#";
+
+    private static String FOUR_MATCH = "#\n" +
+            "# start\n" +
+            "NetType:        Direct Assignment\n" +
+            "Organization:   Direct Assignment Org\n" +
+            "Country:        FOO\n" +
+            "# end\n" +
+            "# start\n" +
+            "NetType:        Direct Allocation\n" +
+            "Organization:   Direct Allocation Org\n" +
+            "Country:        BAR\n" +
+            "# end\n" +
+            "# start\n" +
+            "NetType:        Reassigned\n" +
+            "Customer:       Reassigned Customer\n" +
+            "Country:        BAZ\n" +
+            "# end\n" +
+            "# start\n" +
+            "NetType:        Reallocated\n" +
+            "Customer:       Reallocated Customer\n" +
+            "Country:        MOO\n" +
+            "# end\n";
+
     @Test
     public void testRunDirectMatch() throws Exception {
         ARINResponseParser parser = new ARINResponseParser();
@@ -215,6 +399,34 @@ public class ARINResponseParserTest {
 
         assertEquals("US", parser.getCountryCode());
         assertEquals("AT&T Internet Services (SIS-80)", parser.getOrganization());
+    }
+
+    @Test
+    public void testRunTwoMatches() throws Exception {
+        ARINResponseParser parser = new ARINResponseParser();
+        for (String line : TWO_MATCH.split("\n")) {
+            parser.readLine(line);
+        }
+
+        assertFalse(parser.isRedirect());
+        assertNull(parser.getRegistryRedirect());
+
+        assertEquals("US", parser.getCountryCode());
+        assertEquals("Cox Communications (C00898431)", parser.getOrganization());
+    }
+
+    @Test
+    public void testRunFourMatches() throws Exception {
+        ARINResponseParser parser = new ARINResponseParser();
+        for (String line : FOUR_MATCH.split("\n")) {
+            parser.readLine(line);
+        }
+
+        assertFalse(parser.isRedirect());
+        assertNull(parser.getRegistryRedirect());
+
+        assertEquals("BAZ", parser.getCountryCode());
+        assertEquals("Reassigned Customer", parser.getOrganization());
     }
 
     @Test


### PR DESCRIPTION
This is a backport of #180, which updated the WHOIS data adapter to better handle ARIN results with multiple records.  Verified that it works on 4.0:
<img width="1186" alt="Screen Shot 2020-11-23 at 11 40 52 AM" src="https://user-images.githubusercontent.com/6466251/99995995-bfb05400-2d80-11eb-9c66-bd02f0a69574.png">
