### PR TITLE
Deprecate Ransomware Data Adapter

### DIFF
--- a/src/main/java/org/graylog/plugins/threatintel/adapters/abusech/AbuseChRansomAdapter.java
+++ b/src/main/java/org/graylog/plugins/threatintel/adapters/abusech/AbuseChRansomAdapter.java
@@ -27,10 +27,7 @@ import com.google.common.collect.Multimap;
 import com.google.inject.Inject;
 import com.google.inject.assistedinject.Assisted;
 import org.graylog.autovalue.WithBeanGetter;
-import org.graylog.plugins.threatintel.PluginConfigService;
 import org.graylog.plugins.threatintel.tools.AdapterDisabledException;
-import org.graylog2.lookup.adapters.dsvhttp.DSVParser;
-import org.graylog2.lookup.adapters.dsvhttp.HTTPFileRetriever;
 import org.graylog2.plugin.lookup.LookupCachePurge;
 import org.graylog2.plugin.lookup.LookupDataAdapter;
 import org.graylog2.plugin.lookup.LookupDataAdapterConfiguration;
@@ -42,66 +39,30 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 import javax.validation.constraints.Min;
-import java.io.IOException;
-import java.util.Collections;
-import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
 
 public class AbuseChRansomAdapter extends LookupDataAdapter {
     private static final Logger LOG = LoggerFactory.getLogger(AbuseChRansomAdapter.class);
 
-    // abuse.ch lists are updated every 5 mins, we check more often to avoid lagging behind too much.
-    // the adapter makes conditional requests to avoid reloading the data too often
-    // for changes in update interval and URLs see https://ransomwaretracker.abuse.ch/blocklist/
+    // The abuse.ch Ransomware Tracker was shut down on 2019-12-08.
+    // This Data Adapter is no longer useful.
+
     private static final int REFRESH_INTERVAL = Period.minutes(5).toStandardSeconds().getSeconds() / 2;
 
     public static final String NAME = "abuse-ch-ransom";
-    private static final LookupResult TRUE_RESULT = LookupResult.single(true);
-
-    private final HTTPFileRetriever httpFileRetriever;
-    private final PluginConfigService pluginConfigService;
-    private final AtomicReference<Set<String>> lookupRef = new AtomicReference<>(Collections.emptySet());
-    private final DSVParser dsvParser;
-    private final BlocklistType blocklistType;
 
     @Inject
     public AbuseChRansomAdapter(@Assisted("id") String id,
                                 @Assisted("name") String name,
                                 @Assisted LookupDataAdapterConfiguration config,
-                                MetricRegistry metricRegistry,
-                                HTTPFileRetriever httpFileRetriever,
-                                PluginConfigService pluginConfigService) {
+                                MetricRegistry metricRegistry) {
         super(id, name, config, metricRegistry);
-        this.httpFileRetriever = httpFileRetriever;
-        this.pluginConfigService = pluginConfigService;
-        blocklistType = ((Config) getConfig()).blocklistType();
-        dsvParser = new DSVParser(
-                "#",
-                "\n",
-                ",",
-                "\"",
-                true,
-                blocklistType.isCaseInsensitive(),
-                0,
-                Optional.of(0)
-        );
     }
 
     @Override
     public void doStart() throws Exception {
-        if (!pluginConfigService.config().getCurrent().abusechRansomEnabled()) {
-            throw new AdapterDisabledException("Abuse.ch service is disabled, not starting adapter. To enable it please go to System / Configurations.");
-        }
-        final Config config = ((Config) getConfig());
-        LOG.debug("Starting abuse.ch data adapter for blocklist {}", config.blocklistType());
-        if (config.refreshInterval() < 1) {
-            throw new IllegalStateException("Check interval setting cannot be smaller than 1");
-        }
-
-        loadData();
+        throw new AdapterDisabledException("The abuse.ch Ransomware Tracker was shut down on 2019-12-08. This Data Adapter should be deleted.");
     }
 
     @Override
@@ -111,35 +72,17 @@ public class AbuseChRansomAdapter extends LookupDataAdapter {
 
     @Override
     public Duration refreshInterval() {
-        if (!pluginConfigService.config().getCurrent().abusechRansomEnabled()) {
-            return Duration.ZERO;
-        }
-        return Duration.standardSeconds(((Config) getConfig()).refreshInterval());
+        return Duration.ZERO;
     }
 
     @Override
     protected void doRefresh(LookupCachePurge cachePurge) throws Exception {
-        if (!pluginConfigService.config().getCurrent().abusechRansomEnabled()) {
-            throw new AdapterDisabledException("Abuse.ch service is disabled, not refreshing adapter. To enable it please go to System / Configurations.");
-        }
-        loadData();
-        cachePurge.purgeAll();
-    }
-
-    private void loadData() throws IOException {
-        final Optional<String> response = httpFileRetriever.fetchFileIfNotModified(blocklistType.getUrl());
-
-        response.ifPresent(body -> {
-            final Map<String, String> map = dsvParser.parse(body);
-            lookupRef.set(map.keySet());
-        });
+        throw new AdapterDisabledException("The abuse.ch Ransomware Tracker was shut down on 2019-12-08. This Data Adapter should be deleted.");
     }
 
     @Override
     protected LookupResult doGet(Object key) {
-        return lookupRef.get().contains(key.toString())
-                ? TRUE_RESULT
-                : LookupResult.empty();
+        return LookupResult.empty();
     }
 
     @Override

--- a/src/web/components/ThreatIntelPluginConfig.jsx
+++ b/src/web/components/ThreatIntelPluginConfig.jsx
@@ -112,9 +112,6 @@ const ThreatIntelPluginConfig = createReactClass({
 
           <dt>Spamhaus:</dt>
           <dd>{this.state.config.spamhaus_enabled === true ? 'Enabled' : 'Disabled'}</dd>
-
-          <dt>Abuse.ch Ransomware:</dt>
-          <dd>{this.state.config.abusech_ransom_enabled === true ? 'Enabled' : 'Disabled'}</dd>
         </dl>
 
         <IfPermitted permissions="clusterconfigentry:edit">
@@ -144,15 +141,6 @@ const ThreatIntelPluginConfig = createReactClass({
                    name="tor_enabled"
                    checked={this.state.config.spamhaus_enabled}
                    onChange={this._onCheckboxClick('spamhaus_enabled', 'spamhausEnabled')} />
-
-            <Input type="checkbox"
-                   id="abusech-checkbox"
-                   ref={(elem) => { this.abusechRansomEnabled = elem; }}
-                   label="Allow Abuse.ch Ransomware tracker lookups?"
-                   help="Enable to include Abuse.ch Ransomware tracker lookup in global pipeline function, disabling also stops refreshing the data."
-                   name="tor_enabled"
-                   checked={this.state.config.abusech_ransom_enabled}
-                   onChange={this._onCheckboxClick('abusech_ransom_enabled', 'abusechRansomEnabled')} />
           </fieldset>
         </BootstrapModalForm>
       </div>

--- a/src/web/components/adapters/abusech/AbuseChRansomAdapterDocumentation.jsx
+++ b/src/web/components/adapters/abusech/AbuseChRansomAdapterDocumentation.jsx
@@ -21,14 +21,10 @@ import { Alert } from 'components/graylog';
 const AbuseChRansomAdapterDocumentation = () => {
   return (
     <div>
-      <p>The <a href="https://ransomwaretracker.abuse.ch/blocklist/" target="_blank" rel="noopener noreferrer">abuse.ch ransomware tracker</a> offers various types of blocklists that allows you to block Ransomware botnet C&amp;C traffic.</p>
-
-      <Alert style={{ marginBottom: 10 }} bsStyle="info">
-        <h4 style={{ marginBottom: 10 }}>Limitations</h4>
-        <p>Currently only the combined blocklists are supported.</p>
-        <p>For support of individual blocklists, please visit our support channels.</p>
+      <Alert style={{ marginBottom: 10 }} bsStyle="warning">
+        <h4 style={{ marginBottom: 10 }}>Deprecation Warning</h4>
+        <p>The abuse.ch Ransomware Tracker was shut down on 2019-12-08. This Data Adapter should not be used.</p>
       </Alert>
-
     </div>
   );
 };

--- a/src/web/components/adapters/abusech/AbuseChRansomAdapterSummary.jsx
+++ b/src/web/components/adapters/abusech/AbuseChRansomAdapterSummary.jsx
@@ -16,7 +16,9 @@
  */
 import PropTypes from 'prop-types';
 import React from 'react';
+
 import { TimeUnit } from 'components/common';
+import { Alert } from 'components/graylog';
 
 class AbuseChRansomAdapterSummary extends React.Component {
   static propTypes = {
@@ -24,18 +26,27 @@ class AbuseChRansomAdapterSummary extends React.Component {
   };
 
   render() {
-    const config = this.props.dataAdapter.config;
+    const { config } = this.props.dataAdapter;
     const blocklistType = {
       DOMAINS: 'Domain blocklist',
       URLS: 'URL blocklist',
       IPS: 'IP blocklist',
     };
-    return (<dl>
-      <dt>Blocklist type</dt>
-      <dd>{blocklistType[config.blocklist_type]}</dd>
-      <dt>Update interval</dt>
-      <dd><TimeUnit value={config.refresh_interval} unit={config.refresh_interval_unit} /></dd>
-    </dl>);
+
+    return (
+      <div>
+        <dl>
+          <dt>Blocklist type</dt>
+          <dd>{blocklistType[config.blocklist_type]}</dd>
+          <dt>Update interval</dt>
+          <dd><TimeUnit value={config.refresh_interval} unit={config.refresh_interval_unit} /></dd>
+        </dl>
+        <Alert style={{ marginBottom: 10 }} bsStyle="warning">
+          <h4 style={{ marginBottom: 10 }}>Deprecation Warning</h4>
+          <p>The abuse.ch Ransomware Tracker was shut down on 2019-12-08. This Data Adapter should not be used.</p>
+        </Alert>
+      </div>
+    );
   }
 }
 

--- a/src/web/index.jsx
+++ b/src/web/index.jsx
@@ -15,15 +15,15 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 // eslint-disable-next-line no-unused-vars, import/default, no-unused-vars
-import webpackEntry from 'webpack-entry';
-
 import { PluginManifest, PluginStore } from 'graylog-web-plugin/plugin';
-import ThreatIntelPluginConfig from 'components/ThreatIntelPluginConfig';
 
+import webpackEntry from 'webpack-entry';
+import ThreatIntelPluginConfig from 'components/ThreatIntelPluginConfig';
 import { SpamhausEDROPAdapterDocumentation, SpamhausEDROPAdapterFieldSet, SpamhausEDROPAdapterSummary } from 'components/adapters/spamhaus-edrop';
 import { TorExitNodeAdapterDocumentation, TorExitNodeAdapterFieldSet, TorExitNodeAdapterSummary } from 'components/adapters/torexitnode';
 import { WhoisAdapterDocumentation, WhoisAdapterFieldSet, WhoisAdapterSummary } from 'components/adapters/whois/index';
 import { AbuseChRansomAdapterDocumentation, AbuseChRansomAdapterFieldSet, AbuseChRansomAdapterSummary } from 'components/adapters/abusech/index';
+
 import { OTXAdapterDocumentation, OTXAdapterFieldSet, OTXAdapterSummary } from './components/adapters/otx';
 
 import packageJson from '../../package.json';
@@ -59,7 +59,7 @@ PluginStore.register(new PluginManifest(packageJson, {
     },
     {
       type: 'abuse-ch-ransom',
-      displayName: 'Ransomware blocklists from abuse.ch',
+      displayName: '[Deprecated] Ransomware blocklists from abuse.ch',
       formComponent: AbuseChRansomAdapterFieldSet,
       summaryComponent: AbuseChRansomAdapterSummary,
       documentationComponent: AbuseChRansomAdapterDocumentation,


### PR DESCRIPTION
As of Dec 8, 2019, the Ransomware Tracker at abuse.ch was shut down.  This change adds clear warnings throughout the UI that the Ransomware Data Adapter is deprecated and should no longer be used.  It also updates the back end logic to stop the Data Adapter from calling the deprecated endpoints.

Tested locally
Updated data adapter label in drop-down
<img width="1010" alt="Screen Shot 2020-11-30 at 2 55 29 PM" src="https://user-images.githubusercontent.com/6466251/100670627-c57bdb80-3324-11eb-9c90-b470b13f43ad.png">

Added deprecation warning to create/edit page
<img width="1657" alt="Screen Shot 2020-11-30 at 2 55 17 PM" src="https://user-images.githubusercontent.com/6466251/100670681-d9274200-3324-11eb-9082-4ae40ce7ca26.png">

Added deprecation warning to summary page
<img width="986" alt="Screen Shot 2020-11-30 at 3 55 35 PM" src="https://user-images.githubusercontent.com/6466251/100670747-ef350280-3324-11eb-8464-77f05c8fb8d9.png">

Data Adapter shuts down when run
<img width="735" alt="Screen Shot 2020-11-30 at 2 55 00 PM" src="https://user-images.githubusercontent.com/6466251/100670780-01af3c00-3325-11eb-9ad1-c35356645be5.png">
