### PR TITLE
Exclude commons-logging because we are using jcl-over-slf4j

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,12 @@
             <groupId>commons-validator</groupId>
             <artifactId>commons-validator</artifactId>
             <version>1.6</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.google.auto.value</groupId>


### PR DESCRIPTION
Refs Graylog2/graylog2-server#11454
