### PR TITLE
Bubble up HTTP error codes from data adapter

### DIFF
--- a/src/main/java/org/graylog/plugins/threatintel/adapters/otx/OTXDataAdapter.java
+++ b/src/main/java/org/graylog/plugins/threatintel/adapters/otx/OTXDataAdapter.java
@@ -216,7 +216,8 @@ public class OTXDataAdapter extends LookupDataAdapter {
             if (!response.isSuccessful()) {
                 LOG.warn("OTX {} request for key <{}> failed: {}", otxIndicator, key, response);
                 httpRequestErrors.mark();
-                return LookupResult.withError(key, String.format("OTX %s request for key <%s> failed: %s", otxIndicator, key, response.code()));
+                return LookupResult.withError(
+                        String.format("OTX %s request for key <%s> failed: %s", otxIndicator, key, response.code()));
             }
 
             return parseResponse(response.body());

--- a/src/main/java/org/graylog/plugins/threatintel/adapters/otx/OTXDataAdapter.java
+++ b/src/main/java/org/graylog/plugins/threatintel/adapters/otx/OTXDataAdapter.java
@@ -213,8 +213,7 @@ public class OTXDataAdapter extends LookupDataAdapter {
 
         final Timer.Context time = httpRequestTimer.time();
         try (final Response response = httpClient.newCall(request).execute()) {
-//            if (!response.isSuccessful()) {
-            if (response.isSuccessful()) {
+            if (!response.isSuccessful()) {
                 LOG.warn("OTX {} request for key <{}> failed: {}", otxIndicator, key, response);
                 httpRequestErrors.mark();
                 return LookupResult.withError(key, String.format("OTX %s request for key <%s> failed: %s", otxIndicator, key, response.code()));

--- a/src/main/java/org/graylog/plugins/threatintel/adapters/otx/OTXDataAdapter.java
+++ b/src/main/java/org/graylog/plugins/threatintel/adapters/otx/OTXDataAdapter.java
@@ -72,7 +72,7 @@ public class OTXDataAdapter extends LookupDataAdapter {
     private static final InetAddressValidator INET_ADDRESS_VALIDATOR = InetAddressValidator.getInstance();
     // Don't use the object mapper from ObjectMapperProvider to make sure we are not affected by changes in that one
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-    private static final TypeReference<Map<Object, Object>> MAP_TYPE_REFERENCE = new TypeReference<Map<Object, Object>>() {
+    private static final TypeReference<Map<Object, Object>> MAP_TYPE_REFERENCE = new TypeReference<>() {
     };
 
     private static final String OTX_INDICATOR_IPV4 = "IPv4";
@@ -216,7 +216,7 @@ public class OTXDataAdapter extends LookupDataAdapter {
             if (!response.isSuccessful()) {
                 LOG.warn("OTX {} request for key <{}> failed: {}", otxIndicator, key, response);
                 httpRequestErrors.mark();
-                return LookupResult.empty();
+                throw new IOException("HTTP Request failed with code " + response.code() + ": " + response.message());
             }
 
             return parseResponse(response.body());

--- a/src/main/java/org/graylog/plugins/threatintel/adapters/otx/OTXDataAdapter.java
+++ b/src/main/java/org/graylog/plugins/threatintel/adapters/otx/OTXDataAdapter.java
@@ -309,11 +309,7 @@ public class OTXDataAdapter extends LookupDataAdapter {
     @JsonDeserialize(builder = OTXDataAdapter.Config.Builder.class)
     @JsonTypeName(NAME)
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public static abstract class Config implements LookupDataAdapterConfiguration {
-        @Override
-        @JsonProperty(TYPE_FIELD)
-        public abstract String type();
-
+    public abstract static class Config implements LookupDataAdapterConfiguration {
         @JsonProperty("indicator")
         @NotEmpty
         public abstract String indicator();

--- a/src/main/java/org/graylog/plugins/threatintel/adapters/otx/OTXDataAdapter.java
+++ b/src/main/java/org/graylog/plugins/threatintel/adapters/otx/OTXDataAdapter.java
@@ -213,10 +213,11 @@ public class OTXDataAdapter extends LookupDataAdapter {
 
         final Timer.Context time = httpRequestTimer.time();
         try (final Response response = httpClient.newCall(request).execute()) {
-            if (!response.isSuccessful()) {
+//            if (!response.isSuccessful()) {
+            if (response.isSuccessful()) {
                 LOG.warn("OTX {} request for key <{}> failed: {}", otxIndicator, key, response);
                 httpRequestErrors.mark();
-                throw new IOException("HTTP Request failed with code " + response.code() + ": " + response.message());
+                return LookupResult.withError(key, String.format("OTX %s request for key <%s> failed: %s", otxIndicator, key, response.code()));
             }
 
             return parseResponse(response.body());

--- a/src/main/java/org/graylog/plugins/threatintel/functions/otx/AbstractOTXLookupFunction.java
+++ b/src/main/java/org/graylog/plugins/threatintel/functions/otx/AbstractOTXLookupFunction.java
@@ -22,7 +22,6 @@ import org.graylog.plugins.threatintel.functions.misc.LookupTableFunction;
 import org.graylog2.lookup.LookupTableService;
 import org.graylog2.plugin.lookup.LookupResult;
 
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -50,16 +49,20 @@ abstract class AbstractOTXLookupFunction extends LookupTableFunction<OTXLookupRe
         final LookupResult lookupResult = lookupFunction.lookup(key);
 
         if (lookupResult != null && !lookupResult.isEmpty()) {
+            if (lookupResult.hasError()) {
+                return OTXLookupResult.buildFromError(lookupResult);
+            }
+
             final ImmutableMap.Builder<String, Object> result = ImmutableMap.builder();
             final Object singleValue = lookupResult.singleValue();
-            final Integer pulseCount = singleValue instanceof Integer ? (Integer)singleValue : Integer.valueOf(String.valueOf(singleValue));
+            final Integer pulseCount = singleValue instanceof Integer ? (Integer) singleValue : Integer.valueOf(String.valueOf(singleValue));
 
             if (pulseCount > 0) {
                 result.put("otx_threat_indicated", true);
                 if (lookupResult.multiValue() != null && lookupResult.multiValue() instanceof Map) {
                     Joiner joiner = Joiner.on(", ").skipNulls();
-                    final Map<String, Object> pulse_info = (Map<String, Object>)lookupResult.multiValue().get("pulse_info");
-                    final List<Map<String, Object>> pulses = (List<Map<String, Object>>)pulse_info.get("pulses");
+                    final Map<String, Object> pulse_info = (Map<String, Object>) lookupResult.multiValue().get("pulse_info");
+                    final List<Map<String, Object>> pulses = (List<Map<String, Object>>) pulse_info.get("pulses");
 
                     final List<String> ids = pulses.stream()
                             .map(pulse -> String.valueOf(pulse.get("id")))

--- a/src/main/java/org/graylog/plugins/threatintel/functions/otx/OTXDomainLookupFunction.java
+++ b/src/main/java/org/graylog/plugins/threatintel/functions/otx/OTXDomainLookupFunction.java
@@ -22,11 +22,12 @@ import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionDescriptor;
 import org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor;
 import org.graylog.plugins.threatintel.tools.Domain;
 import org.graylog2.lookup.LookupTableService;
-import org.graylog2.plugin.lookup.LookupResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
+
+import static org.graylog.plugins.threatintel.functions.otx.OTXLookupResult.MESSAGE;
 
 public class OTXDomainLookupFunction extends AbstractOTXLookupFunction {
 
@@ -56,7 +57,7 @@ public class OTXDomainLookupFunction extends AbstractOTXLookupFunction {
         LOG.debug("Running OTX lookup for domain [{}].", domain);
         OTXLookupResult result = lookupDomain(Domain.prepareDomain(domain).trim());
         if (result.hasError()) {
-            throw new RuntimeException((String) result.getResults().get(LookupResult.MESSAGE));
+            throw new RuntimeException((String) result.getResults().get(MESSAGE));
         }
         return result;
     }

--- a/src/main/java/org/graylog/plugins/threatintel/functions/otx/OTXDomainLookupFunction.java
+++ b/src/main/java/org/graylog/plugins/threatintel/functions/otx/OTXDomainLookupFunction.java
@@ -22,6 +22,7 @@ import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionDescriptor;
 import org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor;
 import org.graylog.plugins.threatintel.tools.Domain;
 import org.graylog2.lookup.LookupTableService;
+import org.graylog2.plugin.lookup.LookupResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -53,7 +54,11 @@ public class OTXDomainLookupFunction extends AbstractOTXLookupFunction {
         }
 
         LOG.debug("Running OTX lookup for domain [{}].", domain);
-        return lookupDomain(Domain.prepareDomain(domain).trim());
+        OTXLookupResult result = lookupDomain(Domain.prepareDomain(domain).trim());
+        if (result.hasError()) {
+            throw new RuntimeException((String) result.getResults().get(LookupResult.MESSAGE));
+        }
+        return result;
     }
 
     @Override

--- a/src/main/java/org/graylog/plugins/threatintel/functions/otx/OTXIPLookupFunction.java
+++ b/src/main/java/org/graylog/plugins/threatintel/functions/otx/OTXIPLookupFunction.java
@@ -21,6 +21,7 @@ import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionArgs;
 import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionDescriptor;
 import org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor;
 import org.graylog2.lookup.LookupTableService;
+import org.graylog2.plugin.lookup.LookupResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -54,7 +55,11 @@ public class OTXIPLookupFunction extends AbstractOTXLookupFunction {
 
         LOG.debug("Running OTX lookup for IP [{}].", ip);
 
-        return lookupIP(ip.trim());
+        OTXLookupResult result = lookupIP(ip.trim());
+        if (result.hasError()) {
+            throw new RuntimeException((String) result.getResults().get(LookupResult.MESSAGE));
+        }
+        return result;
     }
 
     @Override

--- a/src/main/java/org/graylog/plugins/threatintel/functions/otx/OTXIPLookupFunction.java
+++ b/src/main/java/org/graylog/plugins/threatintel/functions/otx/OTXIPLookupFunction.java
@@ -21,11 +21,12 @@ import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionArgs;
 import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionDescriptor;
 import org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor;
 import org.graylog2.lookup.LookupTableService;
-import org.graylog2.plugin.lookup.LookupResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
+
+import static org.graylog.plugins.threatintel.functions.otx.OTXLookupResult.MESSAGE;
 
 public class OTXIPLookupFunction extends AbstractOTXLookupFunction {
 
@@ -57,7 +58,7 @@ public class OTXIPLookupFunction extends AbstractOTXLookupFunction {
 
         OTXLookupResult result = lookupIP(ip.trim());
         if (result.hasError()) {
-            throw new RuntimeException((String) result.getResults().get(LookupResult.MESSAGE));
+            throw new RuntimeException((String) result.getResults().get(MESSAGE));
         }
         return result;
     }

--- a/src/main/java/org/graylog/plugins/threatintel/functions/otx/OTXLookupResult.java
+++ b/src/main/java/org/graylog/plugins/threatintel/functions/otx/OTXLookupResult.java
@@ -16,7 +16,6 @@
  */
 package org.graylog.plugins.threatintel.functions.otx;
 
-import com.google.common.base.Joiner;
 import com.google.common.collect.ForwardingMap;
 import com.google.common.collect.ImmutableMap;
 import org.graylog2.plugin.lookup.LookupResult;
@@ -38,24 +37,6 @@ public class OTXLookupResult extends ForwardingMap<String, Object> {
         return new FalseOTXLookupResult(
                 (String) lookupResult.multiValue().get(LOOKUP_KEY),
                 (String) lookupResult.multiValue().get(MESSAGE));
-    }
-
-    public static OTXLookupResult buildFromIntel(OTXIntel intel) {
-        if (intel.getPulseCount() > 0) {
-            ImmutableMap.Builder<String, Object> builder = ImmutableMap.<String, Object>builder();
-
-            // Indicator that threat intelligence was returned for the query.
-            builder.put(OTX_THREAT_INDICATED, true);
-
-            // Add metadata.
-            Joiner joiner = Joiner.on(", ").skipNulls();
-            builder.put("otx_threat_ids", joiner.join(intel.getPulseIds()));
-            builder.put("otx_threat_names", joiner.join(intel.getPulseNames()));
-
-            return new OTXLookupResult(builder.build());
-        } else {
-            return OTXLookupResult.FALSE;
-        }
     }
 
     public OTXLookupResult(ImmutableMap<String, Object> fields) {

--- a/src/main/java/org/graylog/plugins/threatintel/functions/otx/OTXLookupResult.java
+++ b/src/main/java/org/graylog/plugins/threatintel/functions/otx/OTXLookupResult.java
@@ -25,15 +25,19 @@ import java.util.Map;
 
 public class OTXLookupResult extends ForwardingMap<String, Object> {
 
+    public static final String LOOKUP_KEY = "key";
+    public static final String MESSAGE = "message";
+    public static final String HAS_ERROR = "has_error";
+    public static final String OTX_THREAT_INDICATED = "otx_threat_indicated";
     private final ImmutableMap<String, Object> results;
 
-    public static final OTXLookupResult EMPTY = new EmptyOTXLookupResult();
-    public static final OTXLookupResult FALSE = new FalseOTXLookupResult();
+    protected static final OTXLookupResult EMPTY = new EmptyOTXLookupResult();
+    protected static final OTXLookupResult FALSE = new FalseOTXLookupResult();
 
     public static OTXLookupResult buildFromError(LookupResult lookupResult) {
         return new FalseOTXLookupResult(
-                (String) lookupResult.multiValue().get("key"),
-                (String) lookupResult.multiValue().get("message"));
+                (String) lookupResult.multiValue().get(LOOKUP_KEY),
+                (String) lookupResult.multiValue().get(MESSAGE));
     }
 
     public static OTXLookupResult buildFromIntel(OTXIntel intel) {
@@ -41,7 +45,7 @@ public class OTXLookupResult extends ForwardingMap<String, Object> {
             ImmutableMap.Builder<String, Object> builder = ImmutableMap.<String, Object>builder();
 
             // Indicator that threat intelligence was returned for the query.
-            builder.put("otx_threat_indicated", true);
+            builder.put(OTX_THREAT_INDICATED, true);
 
             // Add metadata.
             Joiner joiner = Joiner.on(", ").skipNulls();
@@ -62,6 +66,13 @@ public class OTXLookupResult extends ForwardingMap<String, Object> {
         return results;
     }
 
+    public boolean hasError() {
+        if (results != null && !results.isEmpty()) {
+            return (results.get(HAS_ERROR) != null);
+        }
+        return false;
+    }
+
     @Override
     protected Map<String, Object> delegate() {
         return getResults();
@@ -69,7 +80,7 @@ public class OTXLookupResult extends ForwardingMap<String, Object> {
 
     private static class FalseOTXLookupResult extends OTXLookupResult {
         private static final ImmutableMap<String, Object> EMPTY = ImmutableMap.<String, Object>builder()
-                .put("otx_threat_indicated", false)
+                .put(OTX_THREAT_INDICATED, false)
                 .build();
 
         private FalseOTXLookupResult() {
@@ -78,9 +89,10 @@ public class OTXLookupResult extends ForwardingMap<String, Object> {
 
         private FalseOTXLookupResult(String key, String errMsg) {
             super(ImmutableMap.<String, Object>builder()
-                    .put("otx_threat_indicated", false)
-                    .put("key", key)
-                    .put("message", errMsg)
+                    .put(OTX_THREAT_INDICATED, false)
+                    .put(HAS_ERROR, true)
+                    .put(LOOKUP_KEY, key)
+                    .put(MESSAGE, errMsg)
                     .build());
         }
     }

--- a/src/main/java/org/graylog/plugins/threatintel/functions/otx/OTXLookupResult.java
+++ b/src/main/java/org/graylog/plugins/threatintel/functions/otx/OTXLookupResult.java
@@ -23,8 +23,6 @@ import org.graylog2.plugin.lookup.LookupResult;
 import java.util.Map;
 
 public class OTXLookupResult extends ForwardingMap<String, Object> {
-
-    public static final String LOOKUP_KEY = "key";
     public static final String MESSAGE = "message";
     public static final String HAS_ERROR = "has_error";
     public static final String OTX_THREAT_INDICATED = "otx_threat_indicated";
@@ -34,9 +32,7 @@ public class OTXLookupResult extends ForwardingMap<String, Object> {
     protected static final OTXLookupResult FALSE = new FalseOTXLookupResult();
 
     public static OTXLookupResult buildFromError(LookupResult lookupResult) {
-        return new FalseOTXLookupResult(
-                (String) lookupResult.multiValue().get(LOOKUP_KEY),
-                (String) lookupResult.multiValue().get(MESSAGE));
+        return new FalseOTXLookupResult((String) lookupResult.singleValue());
     }
 
     public OTXLookupResult(ImmutableMap<String, Object> fields) {
@@ -68,11 +64,10 @@ public class OTXLookupResult extends ForwardingMap<String, Object> {
             super(EMPTY);
         }
 
-        private FalseOTXLookupResult(String key, String errMsg) {
+        private FalseOTXLookupResult(String errMsg) {
             super(ImmutableMap.<String, Object>builder()
                     .put(OTX_THREAT_INDICATED, false)
                     .put(HAS_ERROR, true)
-                    .put(LOOKUP_KEY, key)
                     .put(MESSAGE, errMsg)
                     .build());
         }

--- a/src/main/java/org/graylog/plugins/threatintel/functions/otx/OTXLookupResult.java
+++ b/src/main/java/org/graylog/plugins/threatintel/functions/otx/OTXLookupResult.java
@@ -19,6 +19,7 @@ package org.graylog.plugins.threatintel.functions.otx;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ForwardingMap;
 import com.google.common.collect.ImmutableMap;
+import org.graylog2.plugin.lookup.LookupResult;
 
 import java.util.Map;
 
@@ -29,8 +30,14 @@ public class OTXLookupResult extends ForwardingMap<String, Object> {
     public static final OTXLookupResult EMPTY = new EmptyOTXLookupResult();
     public static final OTXLookupResult FALSE = new FalseOTXLookupResult();
 
+    public static OTXLookupResult buildFromError(LookupResult lookupResult) {
+        return new FalseOTXLookupResult(
+                (String) lookupResult.multiValue().get("key"),
+                (String) lookupResult.multiValue().get("message"));
+    }
+
     public static OTXLookupResult buildFromIntel(OTXIntel intel) {
-        if(intel.getPulseCount() > 0) {
+        if (intel.getPulseCount() > 0) {
             ImmutableMap.Builder<String, Object> builder = ImmutableMap.<String, Object>builder();
 
             // Indicator that threat intelligence was returned for the query.
@@ -67,6 +74,14 @@ public class OTXLookupResult extends ForwardingMap<String, Object> {
 
         private FalseOTXLookupResult() {
             super(EMPTY);
+        }
+
+        private FalseOTXLookupResult(String key, String errMsg) {
+            super(ImmutableMap.<String, Object>builder()
+                    .put("otx_threat_indicated", false)
+                    .put("key", key)
+                    .put("message", errMsg)
+                    .build());
         }
     }
 


### PR DESCRIPTION
Resolves Graylog2/graylog-plugin-cloud#1046

When OTX API returns an HTTP error code, bubble up the error and log it in the processing failure stream.

How to test: either use a test proxy to manipulate the returned values; or issue OTX requests at a high rate, which will cause the rate limiter to kick in.

/jenkins-pr-deps Graylog2/graylog2-server#13508